### PR TITLE
Define command fails with invalid xml domain file

### DIFF
--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -522,10 +522,9 @@ def core(module):
                 if guest:
                     # there might be a mismatch between quest 'name' in the module and in the xml
                     module.warn("'xml' is given - ignoring 'name'")
-                found_name = re.search('<name>(.*)</name>', xml).groups()
-                if found_name:
-                    domain_name = found_name[0]
-                else:
+                try:
+                    domain_name = re.search('<name>(.*)</name>', xml).groups()[0]
+                except AttributeError:
                     module.fail_json(msg="Could not find domain 'name' in xml")
 
                 # From libvirt docs (https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainDefineXML):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The define action searches for the domain name into the xml definition to determine if the domain needs to be created or updated. The `xml` variable contains the parsed definition but doesn't guarantee the existence of the name tag. If there is not match to the given pattern the task fails without raising the proper error message.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'groups'
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
virt module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
