### PR TITLE
[WIP] Add support for managing libvirt volumes

### DIFF
--- a/plugins/module_utils/entry.py
+++ b/plugins/module_utils/entry.py
@@ -1,0 +1,2 @@
+class EntryNotFound(Exception):
+    pass

--- a/plugins/module_utils/pool.py
+++ b/plugins/module_utils/pool.py
@@ -1,0 +1,220 @@
+try:
+    import libvirt
+except ImportError:
+    HAS_VIRT = False
+else:
+    HAS_VIRT = True
+
+from ansible_collections.community.libvirt.plugins.module_utils.entry import EntryNotFound
+
+ENTRY_STATE_ACTIVE_MAP = {
+    0: "inactive",
+    1: "active"
+}
+
+ENTRY_STATE_AUTOSTART_MAP = {
+    0: "no",
+    1: "yes"
+}
+
+ENTRY_STATE_PERSISTENT_MAP = {
+    0: "no",
+    1: "yes"
+}
+
+class LibvirtConnection(object):
+
+    def __init__(self, uri, module):
+
+        self.module = module
+
+        conn = libvirt.open(uri)
+
+        if not conn:
+            raise Exception("hypervisor connection failure")
+
+        self.conn = conn
+
+    def find_entry(self, entryid):
+        # entryid = -1 returns a list of everything
+
+        results = []
+
+        # Get active entries
+        for name in self.conn.listStoragePools():
+            entry = self.conn.storagePoolLookupByName(name)
+            results.append(entry)
+
+        # Get inactive entries
+        for name in self.conn.listDefinedStoragePools():
+            entry = self.conn.storagePoolLookupByName(name)
+            results.append(entry)
+
+        if entryid == -1:
+            return results
+
+        for entry in results:
+            if entry.name() == entryid:
+                return entry
+
+        raise EntryNotFound("storage pool %s not found" % entryid)
+
+    def create(self, entryid):
+        if not self.module.check_mode:
+            return self.find_entry(entryid).create()
+        else:
+            try:
+                state = self.find_entry(entryid).isActive()
+            except Exception:
+                return self.module.exit_json(changed=True)
+            if not state:
+                return self.module.exit_json(changed=True)
+
+    def destroy(self, entryid):
+        if not self.module.check_mode:
+            return self.find_entry(entryid).destroy()
+        else:
+            if self.find_entry(entryid).isActive():
+                return self.module.exit_json(changed=True)
+
+    def undefine(self, entryid):
+        if not self.module.check_mode:
+            return self.find_entry(entryid).undefine()
+        else:
+            if not self.find_entry(entryid):
+                return self.module.exit_json(changed=True)
+
+    def get_status2(self, entry):
+        state = entry.isActive()
+        return ENTRY_STATE_ACTIVE_MAP.get(state, "unknown")
+
+    def get_status(self, entryid):
+        if not self.module.check_mode:
+            state = self.find_entry(entryid).isActive()
+            return ENTRY_STATE_ACTIVE_MAP.get(state, "unknown")
+        else:
+            try:
+                state = self.find_entry(entryid).isActive()
+                return ENTRY_STATE_ACTIVE_MAP.get(state, "unknown")
+            except Exception:
+                return ENTRY_STATE_ACTIVE_MAP.get("inactive", "unknown")
+
+    def get_uuid(self, entryid):
+        return self.find_entry(entryid).UUIDString()
+
+    def get_xml(self, entryid):
+        return self.find_entry(entryid).XMLDesc(0)
+
+    def get_info(self, entryid):
+        return self.find_entry(entryid).info()
+
+    def get_volume_count(self, entryid):
+        return self.find_entry(entryid).numOfVolumes()
+
+    def get_volume_names(self, entryid):
+        return self.find_entry(entryid).listVolumes()
+
+    def get_devices(self, entryid):
+        xml = etree.fromstring(self.find_entry(entryid).XMLDesc(0))
+        if xml.xpath('/pool/source/device'):
+            result = []
+            for device in xml.xpath('/pool/source/device'):
+                result.append(device.get('path'))
+        try:
+            return result
+        except Exception:
+            raise ValueError('No devices specified')
+
+    def get_format(self, entryid):
+        xml = etree.fromstring(self.find_entry(entryid).XMLDesc(0))
+        try:
+            result = xml.xpath('/pool/source/format')[0].get('type')
+        except Exception:
+            raise ValueError('Format not specified')
+        return result
+
+    def get_host(self, entryid):
+        xml = etree.fromstring(self.find_entry(entryid).XMLDesc(0))
+        try:
+            result = xml.xpath('/pool/source/host')[0].get('name')
+        except Exception:
+            raise ValueError('Host not specified')
+        return result
+
+    def get_source_path(self, entryid):
+        xml = etree.fromstring(self.find_entry(entryid).XMLDesc(0))
+        try:
+            result = xml.xpath('/pool/source/dir')[0].get('path')
+        except Exception:
+            raise ValueError('Source path not specified')
+        return result
+
+    def get_path(self, entryid):
+        xml = etree.fromstring(self.find_entry(entryid).XMLDesc(0))
+        return xml.xpath('/pool/target/path')[0].text
+
+    def get_type(self, entryid):
+        xml = etree.fromstring(self.find_entry(entryid).XMLDesc(0))
+        return xml.get('type')
+
+    def build(self, entryid, flags):
+        if not self.module.check_mode:
+            return self.find_entry(entryid).build(flags)
+        else:
+            try:
+                state = self.find_entry(entryid)
+            except Exception:
+                return self.module.exit_json(changed=True)
+            if not state:
+                return self.module.exit_json(changed=True)
+
+    def delete(self, entryid, flags):
+        if not self.module.check_mode:
+            return self.find_entry(entryid).delete(flags)
+        else:
+            try:
+                state = self.find_entry(entryid)
+            except Exception:
+                return self.module.exit_json(changed=True)
+            if state:
+                return self.module.exit_json(changed=True)
+
+    def get_autostart(self, entryid):
+        state = self.find_entry(entryid).autostart()
+        return ENTRY_STATE_AUTOSTART_MAP.get(state, "unknown")
+
+    def get_autostart2(self, entryid):
+        if not self.module.check_mode:
+            return self.find_entry(entryid).autostart()
+        else:
+            try:
+                return self.find_entry(entryid).autostart()
+            except Exception:
+                return self.module.exit_json(changed=True)
+
+    def set_autostart(self, entryid, val):
+        if not self.module.check_mode:
+            return self.find_entry(entryid).setAutostart(val)
+        else:
+            try:
+                state = self.find_entry(entryid).autostart()
+            except Exception:
+                return self.module.exit_json(changed=True)
+            if bool(state) != val:
+                return self.module.exit_json(changed=True)
+
+    def refresh(self, entryid):
+        return self.find_entry(entryid).refresh()
+
+    def get_persistent(self, entryid):
+        state = self.find_entry(entryid).isPersistent()
+        return ENTRY_STATE_PERSISTENT_MAP.get(state, "unknown")
+
+    def define_from_xml(self, entryid, xml):
+        if not self.module.check_mode:
+            return self.conn.storagePoolDefineXML(xml)
+        else:
+            try:
+                self.find_entry(entryid)
+            except Exception:
+                return self.module.exit_json(changed=True)

--- a/tests/integration/targets/virt_volume/aliases
+++ b/tests/integration/targets/virt_volume/aliases
@@ -1,0 +1,6 @@
+shippable/posix/group1
+skip/aix
+skip/freebsd
+skip/osx
+needs/privileged
+destructive

--- a/tests/integration/targets/virt_volume/files/foobar.xml
+++ b/tests/integration/targets/virt_volume/files/foobar.xml
@@ -1,0 +1,6 @@
+<pool type="dir">
+  <name>foobar</name>
+  <target>
+    <path>/var/lib/virt/images</path>
+  </target>
+</pool>

--- a/tests/integration/targets/virt_volume/files/test1.xml
+++ b/tests/integration/targets/virt_volume/files/test1.xml
@@ -1,0 +1,13 @@
+<volume>
+  <name>test1.img</name>
+  <allocation>0</allocation>
+  <capacity unit="G">2</capacity>
+  <target>
+    <permissions>
+      <owner>107</owner>
+      <group>107</group>
+      <mode>0744</mode>
+      <label>virt_image_t</label>
+    </permissions>
+  </target>
+</volume>

--- a/tests/integration/targets/virt_volume/tasks/main.yml
+++ b/tests/integration/targets/virt_volume/tasks/main.yml
@@ -1,0 +1,85 @@
+---
+- include_vars: '{{ item }}'
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_version}}.yml"
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "default.yml"
+
+- block:
+    - name: Install libvirt packages
+      package:
+        name: "{{ virt_net_packages }}"
+
+    - name: Start libvirt
+      service:
+        name: libvirtd
+        state: started
+
+    - name: Create Storage Pool Dir
+      file:
+        path: /var/lib/virt/images
+        state: directory
+        recurse: yes
+
+    - name: Define the foobar storage pool
+      virt_pool:
+        command: define
+        name: foobar
+        xml: '{{ lookup("file", "foobar.xml") }}'
+    
+    - name: Start the default pool
+      virt_pool:
+        uri: qemu:///system
+        state: active
+        name: foobar
+    
+    - name: Create Volume test1
+      virt_volume:
+        name: test1
+        pool: foobar
+        state: present
+        xml: '{{ lookup("file", "test1.xml") }}'
+
+    - name: List Volumes
+      virt_volume:
+        pool: foobar
+        command: list_volumes
+      register: list_volumes1
+    
+    - name: Create Volume test1 again
+      virt_volume:
+        name: test1
+        pool: foobar
+        state: present
+        xml: '{{ lookup("file", "test1.xml") }}'
+      register: create_test1_2
+      debugger: always
+
+    - name: Destroy the foobar pool
+      virt_pool:
+        command: destroy
+        name: foobar
+
+    - name: Ensures stuff
+      assert:
+        that:
+          - '"test1.img" in list_volumes1'
+
+    # - name: Ensure the second calls return "unchanged"
+    #   assert:
+    #     that:
+    #       - "second_virt_net_start is not changed"
+    #       - "second_virt_net_define is not changed"
+    #       - "second_virt_net_undefine is not changed"
+    
+  always:
+    - name: Stop libvirt
+      service:
+        name: libvirtd
+        state: stopped
+
+    - name: Remove only the libvirt packages
+      package:
+        name: "{{ virt_net_packages|select('match', '.*libvirt.*')|list }}"
+        state: absent

--- a/tests/integration/targets/virt_volume/vars/Debian.yml
+++ b/tests/integration/targets/virt_volume/vars/Debian.yml
@@ -1,0 +1,6 @@
+---
+virt_net_packages:
+  - libvirt-daemon
+  - libvirt-daemon-system
+  - python-libvirt
+  - python-lxml

--- a/tests/integration/targets/virt_volume/vars/Fedora-29.yml
+++ b/tests/integration/targets/virt_volume/vars/Fedora-29.yml
@@ -1,0 +1,6 @@
+---
+virt_net_packages:
+  - libvirt
+  - libvirt-daemon
+  - python3-libvirt
+  - python3-lxml

--- a/tests/integration/targets/virt_volume/vars/RedHat-7.yml
+++ b/tests/integration/targets/virt_volume/vars/RedHat-7.yml
@@ -1,0 +1,6 @@
+---
+virt_net_packages:
+  - libvirt
+  - libvirt-daemon
+  - libvirt-python
+  - python-lxml

--- a/tests/integration/targets/virt_volume/vars/RedHat-8.yml
+++ b/tests/integration/targets/virt_volume/vars/RedHat-8.yml
@@ -1,0 +1,6 @@
+---
+virt_net_packages:
+  - libvirt
+  - libvirt-daemon
+  - python3-libvirt
+  - python3-lxml

--- a/tests/integration/targets/virt_volume/vars/Ubuntu-16.04.yml
+++ b/tests/integration/targets/virt_volume/vars/Ubuntu-16.04.yml
@@ -1,0 +1,5 @@
+---
+virt_net_packages:
+  - libvirt-daemon
+  - python-libvirt
+  - python-lxml

--- a/tests/integration/targets/virt_volume/vars/Ubuntu-18.04.yml
+++ b/tests/integration/targets/virt_volume/vars/Ubuntu-18.04.yml
@@ -1,0 +1,5 @@
+---
+virt_net_packages:
+  - libvirt-daemon
+  - python-libvirt
+  - python-lxml

--- a/tests/integration/targets/virt_volume/vars/Ubuntu-18.10.yml
+++ b/tests/integration/targets/virt_volume/vars/Ubuntu-18.10.yml
@@ -1,0 +1,6 @@
+---
+virt_net_packages:
+  - libvirt-daemon
+  - libvirt-daemon-system
+  - python-libvirt
+  - python-lxml

--- a/tests/integration/targets/virt_volume/vars/default.yml
+++ b/tests/integration/targets/virt_volume/vars/default.yml
@@ -1,0 +1,5 @@
+---
+virt_net_packages:
+  - libvirt-daemon
+  - python-libvirt
+  - python-lxml


### PR DESCRIPTION
##### SUMMARY
This PR adds support for defining libvirt volumes (via `libvirt_volume`).
Currently, this is in a very basic WIP state, but I was able to define a volume and list existing volumes :)

Opening it up, since I have some questions regarding how to implement certain stuff best (see below).

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
libvirt_volume

##### ADDITIONAL INFORMATION
To start out, I just copied the stuff from `libvirt_pool` over and modified it to my needs.
I also need to query pool information, so I refactored the `Libvirtconnection` out of `libvirt_pool` into a `module_utils`. It should probably be renamed now.
However, I am not entirely sure whether this is the intended way to do this inside an ansible collection? I was only able to import it from there by supplying the fully qualified path, which seems a bit silly.

Furthermore, how should the idempotency be handled here? For example, if I have the following in a playbook:

```yaml
    - name: Create Volume
      community.libvirt.virt_volume:
        name: main_os
        pool: vg_vm_storage
        state: present
        xml: '{{ lookup("file", "./templates/os_disk.xml") }}'
```

And I change the template to have less / more storage, should the volume be resized automatically?