### PR TITLE
virt: Return status changed when re-defining domain

### DIFF
--- a/changelogs/fragments/48-virt-detect-domain-update.yml
+++ b/changelogs/fragments/48-virt-detect-domain-update.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - virt - Return "changed" status when using "define" command and domain XML was updated

--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -537,14 +537,16 @@ def core(module):
                 #
                 # In case a domain would be indeed overwritten, we should protect idempotency:
                 try:
-                    existing_domain = v.get_vm(domain_name)
+                    existing_domain_xml = v.get_vm(domain_name).XMLDesc(
+                        libvirt.VIR_DOMAIN_XML_INACTIVE
+                    )
                 except VMNotFound:
-                    existing_domain = None
+                    existing_domain_xml = None
                 try:
                     domain = v.define(xml)
-                    if existing_domain:
+                    if existing_domain_xml:
                         # if we are here, then libvirt redefined existing domain as the doc promised
-                        if existing_domain.XMLDesc() != domain.XMLDesc():
+                        if existing_domain_xml != domain.XMLDesc(libvirt.VIR_DOMAIN_XML_INACTIVE):
                             res = {'changed': True, 'change_reason': 'config changed'}
                     else:
                         res = {'changed': True, 'created': domain.name()}


### PR DESCRIPTION
##### SUMMARY
When using command `define` with module `virt`, originally it checked whether the domain was updated by calling `XMLDesc()` on object representing the old domain and comparing it with the result of `XMLDesc()` called on the object representing the new domain. However, after update, both objects referenced the same domain, therefore both calls returned the same XML and the module never detected any change.

Now, `virt` module gets the original domain XML before updating it.

Also, `XMLDesc()` returns configuration of running domain, since we are updating persistent configuration, we must explicitly request XML of inactive domain, otherwise config change won't be detected if the domain is running.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
virt

##### ADDITIONAL INFORMATION
Tested on:
- Arch Linux, libvirt 6.5.0-3 (libvirt-python 6.9.0) with KVM guest
- CentOS 8, libvirt 4.5.0 (libvirt-python 4.5.0) with KVM guest.

PR with these changes was originally opened here: https://github.com/ansible/ansible/pull/63433
