### PR TITLE
virt_net: Make name parameter optional

### DIFF
--- a/plugins/modules/virt_net.py
+++ b/plugins/modules/virt_net.py
@@ -17,7 +17,7 @@ description:
      - Manage I(libvirt) networks.
 options:
     name:
-        required: True
+        required: False
         aliases: ['network']
         description:
             - name of the network being managed. Note that network must be previously
@@ -602,14 +602,25 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(aliases=['network'], required=True),
+            name=dict(aliases=['network']),
             state=dict(choices=['active', 'inactive', 'present', 'absent']),
             command=dict(choices=ALL_COMMANDS),
             uri=dict(default='qemu:///system'),
             xml=dict(),
             autostart=dict(type='bool')
         ),
-        supports_check_mode=True
+        supports_check_mode=True,
+        required_if=[
+            ('command', 'create', ['name']),
+            ('command', 'status', ['name']),
+            ('command', 'start', ['name']),
+            ('command', 'stop', ['name']),
+            ('command', 'undefine', ['name']),
+            ('command', 'destroy', ['name']),
+            ('command', 'get_xml', ['name']),
+            ('command', 'define', ['name']),
+            ('command', 'modify', ['name']),
+        ]
     )
 
     if not HAS_VIRT:

--- a/tests/integration/targets/virt_net/tasks/main.yml
+++ b/tests/integration/targets/virt_net/tasks/main.yml
@@ -17,51 +17,48 @@
         state: started
 
     - name: Define the foobar network
-      virt_net:
+      community.libvirt.virt_net:
         command: define
         name: foobar
         xml: '{{ lookup("file", "foobar.xml") }}'
-    
+
     - name: Define the foobar network (again)
-      virt_net:
+      community.libvirt.virt_net:
         command: define
         name: foobar
         xml: '{{ lookup("file", "foobar.xml") }}'
       register: second_virt_net_define
-    
-    - name: Start the default network
-      virt_net:
-        uri: qemu:///system
+
+    - name: Start the foobar network
+      community.libvirt.virt_net:
         command: start
         name: foobar
-    
-    - name: Start the default network (again)
-      virt_net:
-        uri: qemu:///system
+
+    - name: Start the foobar network (again)
+      community.libvirt.virt_net:
         command: start
         name: foobar
       register: second_virt_net_start
 
-    - name: Get facts for default network
-      virt_net:
-        uri: qemu:///system
+    - name: Get facts for the foobar network
+      community.libvirt.virt_net:
         command: facts
         name: foobar
       register: virt_net_facts
 
     - name: Destroy the foobar network
-      virt_net:
+      community.libvirt.virt_net:
         command: destroy
         name: foobar
 
     - name: Undefine the foobar network
-      virt_net:
+      community.libvirt.virt_net:
         command: undefine
         name: foobar
       register: second_virt_net_define
 
     - name: Undefine the foobar network (again)
-      virt_net:
+      community.libvirt.virt_net:
         command: undefine
         name: foobar
       register: second_virt_net_undefine
@@ -72,7 +69,15 @@
           - "second_virt_net_start is not changed"
           - "second_virt_net_define is not changed"
           - "second_virt_net_undefine is not changed"
-    
+
+    - name: List all the networks
+      community.libvirt.virt_net:
+        command: list_nets
+
+    - name: Get all the network facts
+      community.libvirt.virt_net:
+        command: facts
+
   always:
     - name: Stop libvirt
       service:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The name parameter is not required for the list_nets or facts
command so we adjust the module to allow for that.

Fixes #49
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
virt_net

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
