### PR TITLE
Split of doc_fragments for virt options

### DIFF
--- a/plugins/doc_fragments/virt.py
+++ b/plugins/doc_fragments/virt.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+
 class ModuleDocFragment(object):
     OPTIONS_GUEST = r"""
 options:
@@ -38,7 +39,7 @@ options:
     choices: [ create, define, destroy, freemem, get_xml, info, list_vms, nodeinfo, pause, shutdown, start, status, stop, undefine, unpause, virttype ]
     type: str
     """
-    
+
     OPTIONS_AUTOSTART = r"""
 options:
   autostart:

--- a/plugins/doc_fragments/virt.py
+++ b/plugins/doc_fragments/virt.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+class ModuleDocFragment(object):
+    OPTIONS_GUEST = r"""
+options:
+  name:
+    description:
+      - name of the guest VM being managed. Note that VM must be previously
+        defined with xml.
+      - This option is required unless I(command) is C(list_vms) or C(info).
+    type: str
+    aliases:
+      - guest
+      """
+
+    OPTIONS_STATE = r"""
+options:
+  state:
+    description:
+      - Note that there may be some lag for state requests like C(shutdown)
+        since these refer only to VM states. After starting a guest, it may not
+        be immediately accessible.
+        state and command are mutually exclusive except when command=list_vms. In
+        this case all VMs in specified state will be listed.
+    choices: [ destroyed, paused, running, shutdown ]
+    type: str
+    """
+
+    OPTIONS_COMMAND = r"""
+options:
+  command:
+    description:
+      - In addition to state management, various non-idempotent commands are available.
+    choices: [ create, define, destroy, freemem, get_xml, info, list_vms, nodeinfo, pause, shutdown, start, status, stop, undefine, unpause, virttype ]
+    type: str
+    """
+    
+    OPTIONS_AUTOSTART = r"""
+options:
+  autostart:
+    description:
+      - Start VM at host startup.
+    type: bool
+    """
+
+    OPTIONS_URI = r"""
+options:
+  uri:
+    description:
+      - Libvirt connection uri.
+    default: qemu:///system
+    type: str
+    """
+
+    OPTIONS_XML = r"""
+options:
+  xml:
+    description:
+      - XML document used with the define command.
+      - Must be raw XML content using C(lookup). XML cannot be reference to a file.
+    type: str
+    """

--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -16,43 +16,13 @@ module: virt
 short_description: Manages virtual machines supported by libvirt
 description:
      - Manages virtual machines supported by I(libvirt).
-options:
-  name:
-    description:
-      - Name of the guest VM being managed. Note that VM must be previously
-        defined with xml.
-      - This option is required unless I(command) is C(list_vms) or C(info).
-    type: str
-    aliases:
-      - guest
-  state:
-    description:
-      - Note that there may be some lag for state requests like C(shutdown)
-        since these refer only to VM states. After starting a guest, it may not
-        be immediately accessible.
-        state and command are mutually exclusive except when command=list_vms. In
-        this case all VMs in specified state will be listed.
-    choices: [ destroyed, paused, running, shutdown ]
-    type: str
-  command:
-    description:
-      - In addition to state management, various non-idempotent commands are available.
-    choices: [ create, define, destroy, freemem, get_xml, info, list_vms, nodeinfo, pause, shutdown, start, status, stop, undefine, unpause, virttype ]
-    type: str
-  autostart:
-    description:
-      - Start VM at host startup.
-    type: bool
-  uri:
-    description:
-      - Libvirt connection uri.
-    default: qemu:///system
-    type: str
-  xml:
-    description:
-      - XML document used with the define command.
-      - Must be raw XML content using C(lookup). XML cannot be reference to a file.
-    type: str
+extends_documentation_fragment:
+    - community.libvirt.virt.options_uri
+    - community.libvirt.virt.options_xml
+    - community.libvirt.virt.options_guest
+    - community.libvirt.virt.options_autostart
+    - community.libvirt.virt.options_state
+    - community.libvirt.virt.options_command
 requirements:
     - python >= 2.6
     - libvirt-python

--- a/plugins/modules/virt_net.py
+++ b/plugins/modules/virt_net.py
@@ -45,15 +45,9 @@ options:
         type: bool
         description:
             - Specify if a given network should be started automatically on system boot.
-    uri:
-        default: "qemu:///system"
-        description:
-            - Libvirt connection uri.
-        type: str
-    xml:
-        description:
-            - XML document used with the define command.
-        type: str
+extends_documentation_fragment:
+    - community.libvirt.virt.options_uri
+    - community.libvirt.virt.options_xml
 requirements:
     - "python >= 2.6"
     - "python-libvirt"

--- a/plugins/modules/virt_pool.py
+++ b/plugins/modules/virt_pool.py
@@ -59,6 +59,9 @@ options:
         description:
             - Pass additional parameters to 'build' or 'delete' commands.
         type: str
+extends_documentation_fragment:
+    - community.libvirt.virt.options_uri
+    - community.libvirt.virt.options_xml
 requirements:
     - "python >= 2.6"
     - "python-libvirt"

--- a/plugins/modules/virt_pool.py
+++ b/plugins/modules/virt_pool.py
@@ -45,15 +45,6 @@ options:
         type: bool
         description:
             - Specify if a given storage pool should be started automatically on system boot.
-    uri:
-        default: "qemu:///system"
-        description:
-            - I(libvirt) connection uri.
-        type: str
-    xml:
-        description:
-            - XML document used with the define command.
-        type: str
     mode:
         choices: [ 'new', 'repair', 'resize', 'no_overwrite', 'overwrite', 'normal', 'zeroed' ]
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This moves the options for the virt.py module into doc_fragments and reuses them for virt_net and virt_pool.
This is to facilitate reuse and further developments of the modules, eg to split into per command modules (+_info  modules)
 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
virt.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
