### PR TITLE
Fix `community.libvirt.libvirt` inventory plugin

### DIFF
--- a/changelogs/fragments/73-plugin-name-fqcn.yaml
+++ b/changelogs/fragments/73-plugin-name-fqcn.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - libvirt inventory plugin - Use FQCN for the inventory plugin name for compatibility with Ansible 2.10 and above.

--- a/plugins/inventory/libvirt.py
+++ b/plugins/inventory/libvirt.py
@@ -16,7 +16,7 @@ options:
     plugin:
         description: Token that ensures this is a source file for the 'libvirt' plugin.
         required: True
-        choices: ['libvirt']
+        choices: ['community.libvirt.libvirt']
     uri:
         description: Libvirt Connection URI
         required: True


### PR DESCRIPTION
##### SUMMARY

Fix the `community.libvirt.libvirt` inventory plugin with the latest version of Ansible.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- `community.libvirt.libvirt` inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

I have an Ansible playbook that targets a `libvirt` VM.
Concretely, I have this in my `$ANSIBLE_CONFIG` file:
```ini
[defaults]
inventory = inventory-libvirt.yaml

[inventory]
enable_plugins = community.libvirt.libvirt
```

And my `inventory-libvirt.yaml` file contains:
```yaml
plugin: community.libvirt.libvirt
uri: 'qemu:///system'
```

This setup used to work but is now broken with this version:
```sh
$ ansible --version
ansible [core 2.11.1] 

$ ansible-galaxy collection list | grep libvirt
community.libvirt             1.0.1  
```

I know get the following error:
```sh
$ ANSIBLE_CONFIG=ansible-libvirt.cfg ansible-playbook -C -D archlinux-vm.yml 
[WARNING]:  * Failed to parse /home/lenaic/doc/devel/perso/lenaic_config/inventory-libvirt.yaml with
ansible_collections.community.libvirt.plugins.inventory.libvirt plugin: Invalid value
"community.libvirt.libvirt" for configuration option "plugin_type: inventory plugin:
ansible_collections.community.libvirt.plugins.inventory.libvirt setting: plugin ", valid values are:
['libvirt']
[WARNING]: Unable to parse /home/lenaic/doc/devel/perso/lenaic_config/inventory-libvirt.yaml as an inventory
source
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does
not match 'all'
[WARNING]: Could not match supplied host pattern, ignoring: archlinux-vm

PLAY [archlinux-vm] ******************************************************************************************
skipping: no hosts matched
```

Replacing the `plugin` value by the suggested value in my `inventory-libvirt.cfg` file like this:
```diff
--- a/inventory-libvirt.yaml
+++ b/inventory-libvirt.yaml
@@ -1,2 +1,2 @@
-plugin: community.libvirt.libvirt
+plugin: libvirt
 uri: 'qemu:///system'
```
didn’t help.

With this new version, I get this error:
```sh
$ ANSIBLE_CONFIG=ansible-libvirt.cfg ansible-playbook -C -D archlinux-vm.yml 
[WARNING]:  * Failed to parse /home/lenaic/doc/devel/perso/lenaic_config/inventory-libvirt.yaml with
ansible_collections.community.libvirt.plugins.inventory.libvirt plugin: Incorrect plugin name in file:
libvirt
[WARNING]: Unable to parse /home/lenaic/doc/devel/perso/lenaic_config/inventory-libvirt.yaml as an inventory
source
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does
not match 'all'
[WARNING]: Could not match supplied host pattern, ignoring: archlinux-vm

PLAY [archlinux-vm] ******************************************************************************************
skipping: no hosts matched
```

This PR fixes this issue.
With this change, my playbook works again. 