### PR TITLE
fix: inventory not being parsed

### DIFF
--- a/plugins/inventory/libvirt.py
+++ b/plugins/inventory/libvirt.py
@@ -16,7 +16,7 @@ options:
     plugin:
         description: Token that ensures this is a source file for the 'libvirt' plugin.
         required: True
-        choices: ['libvirt']
+        choices: ['community.libvirt.libvirt']
     uri:
         description: Libvirt Connection URI
         required: True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Examples of inventory plugin usage were not working. Plugin doc required 'plugin' field to be
'libvirt'.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`libvirt` inventory plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Tested with ansible 2.11.1

<!--- Paste verbatim command output below, e.g. before and after your change -->
BEFORE
```
$ ansible-inventory -i inventory-libvirt.yml --graph
[WARNING]:  * Failed to parse /home/user/project/inventory-libvirt.yml with ansible_collections.community.libvirt.plugins.inventory.libvirt plugin: Invalid value "community.libvirt.libvirt" for
configuration option "plugin_type: inventory plugin: ansible_collections.community.libvirt.plugins.inventory.libvirt setting: plugin ", valid values are: ['libvirt']
[WARNING]: Unable to parse /home/user/project/inventory-libvirt.yml as an inventory source
[WARNING]: No inventory was parsed, only implicit localhost is available
@all:
  |--@ungrouped:
```
AFTER
```
$ ansible-inventory -i inventory-libvirt.yml --graph
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
@all:
  |--@3c1ee79e-5da3-4257-9690-ad2366ada8c2:
  |  |--my-machine
  |--@ungrouped:
```
