### PR TITLE
CI: replace FreeBSD 12.2 with 12.3 for remote devel

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -244,8 +244,8 @@ stages:
               test: rhel/7.9
             - name: RHEL 8.5
               test: rhel/8.5
-            - name: FreeBSD 12.2
-              test: freebsd/12.2
+            - name: FreeBSD 12.3
+              test: freebsd/12.3
             - name: FreeBSD 13.0
               test: freebsd/13.0
 


### PR DESCRIPTION
FreeBSD 12.2 is deprecated and needs to be replaced with 12.3 for Azure
pipelines running against the devel branch.

Relates to https://github.com/ansible-collections/overview/issues/45

Fixes #102 