### PR TITLE
CI: remove centos8 from test matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -135,8 +135,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 33
               test: fedora33
             - name: Fedora 34
@@ -162,8 +160,6 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 32
               test: fedora32
             - name: Fedora 33
@@ -189,8 +185,6 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 31
               test: fedora31
             - name: Fedora 32
@@ -216,8 +210,6 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 31
               test: fedora31
             - name: Fedora 32

--- a/shippable.yml
+++ b/shippable.yml
@@ -26,7 +26,6 @@ matrix:
     - env: T=freebsd/12.1/1
     - env: T=linux/centos6/1
     - env: T=linux/centos7/1
-    - env: T=linux/centos8/1
     - env: T=linux/fedora31/1
     - env: T=linux/fedora32/1
     - env: T=linux/opensuse15py2/1


### PR DESCRIPTION
##### SUMMARY

CentOS 8 has been fully discontinued and mirrors are removing content.

This patch removes centos8 from the test matrix.

Relates to https://github.com/ansible-collections/news-for-maintainers/issues/3

##### ISSUE TYPE

- CI Pull Request
