### PR TITLE
make virt_net modify idempotent, always modify live and config (fixes #107)

### DIFF
--- a/plugins/modules/virt_net.py
+++ b/plugins/modules/virt_net.py
@@ -227,9 +227,14 @@ class LibvirtConnection(object):
             if host is None:
                 # add the host
                 if not self.module.check_mode:
-                    res = network.update(libvirt.VIR_NETWORK_UPDATE_COMMAND_ADD_LAST,
-                                         libvirt.VIR_NETWORK_SECTION_IP_DHCP_HOST,
-                                         -1, xml, libvirt.VIR_NETWORK_UPDATE_AFFECT_LIVE | libvirt.VIR_NETWORK_UPDATE_AFFECT_CONFIG)
+                    if network.isActive():
+                        res = network.update(libvirt.VIR_NETWORK_UPDATE_COMMAND_ADD_LAST,
+                                             libvirt.VIR_NETWORK_SECTION_IP_DHCP_HOST,
+                                             -1, xml, libvirt.VIR_NETWORK_UPDATE_AFFECT_LIVE | libvirt.VIR_NETWORK_UPDATE_AFFECT_CONFIG)
+                    else:
+                        res = network.update(libvirt.VIR_NETWORK_UPDATE_COMMAND_ADD_LAST,
+                                             libvirt.VIR_NETWORK_SECTION_IP_DHCP_HOST,
+                                             -1, xml, libvirt.VIR_NETWORK_UPDATE_AFFECT_CONFIG)
                 else:
                     # pretend there was a change
                     res = 0
@@ -241,9 +246,14 @@ class LibvirtConnection(object):
                     return False
                 else:
                     if not self.module.check_mode:
-                        res = network.update(libvirt.VIR_NETWORK_UPDATE_COMMAND_MODIFY,
-                                             libvirt.VIR_NETWORK_SECTION_IP_DHCP_HOST,
-                                             -1, xml, libvirt.VIR_NETWORK_UPDATE_AFFECT_LIVE | libvirt.VIR_NETWORK_UPDATE_AFFECT_CONFIG)
+                        if network.isActive():
+                            res = network.update(libvirt.VIR_NETWORK_UPDATE_COMMAND_MODIFY,
+                                                 libvirt.VIR_NETWORK_SECTION_IP_DHCP_HOST,
+                                                 -1, xml, libvirt.VIR_NETWORK_UPDATE_AFFECT_LIVE | libvirt.VIR_NETWORK_UPDATE_AFFECT_CONFIG)
+                        else:
+                            res = network.update(libvirt.VIR_NETWORK_UPDATE_COMMAND_MODIFY,
+                                                 libvirt.VIR_NETWORK_SECTION_IP_DHCP_HOST,
+                                                 -1, xml, libvirt.VIR_NETWORK_UPDATE_AFFECT_CONFIG)
                     else:
                         # pretend there was a change
                         res = 0

--- a/plugins/modules/virt_net.py
+++ b/plugins/modules/virt_net.py
@@ -229,7 +229,7 @@ class LibvirtConnection(object):
                 if not self.module.check_mode:
                     res = network.update(libvirt.VIR_NETWORK_UPDATE_COMMAND_ADD_LAST,
                                          libvirt.VIR_NETWORK_SECTION_IP_DHCP_HOST,
-                                         -1, xml, libvirt.VIR_NETWORK_UPDATE_AFFECT_CURRENT)
+                                         -1, xml, libvirt.VIR_NETWORK_UPDATE_AFFECT_LIVE | libvirt.VIR_NETWORK_UPDATE_AFFECT_CONFIG)
                 else:
                     # pretend there was a change
                     res = 0
@@ -243,7 +243,7 @@ class LibvirtConnection(object):
                     if not self.module.check_mode:
                         res = network.update(libvirt.VIR_NETWORK_UPDATE_COMMAND_MODIFY,
                                              libvirt.VIR_NETWORK_SECTION_IP_DHCP_HOST,
-                                             -1, xml, libvirt.VIR_NETWORK_UPDATE_AFFECT_CURRENT)
+                                             -1, xml, libvirt.VIR_NETWORK_UPDATE_AFFECT_LIVE | libvirt.VIR_NETWORK_UPDATE_AFFECT_CONFIG)
                     else:
                         # pretend there was a change
                         res = 0


### PR DESCRIPTION
##### SUMMARY
Before, the modify function was not idempotent (change result depended on whether network was active or not).
This lead to #107. This PR fixes that.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`virt_net`
