### PR TITLE
Remove usage of distutils.spawn

### DIFF
--- a/changelogs/fragments/114_replace_distutils_spawn.yml
+++ b/changelogs/fragments/114_replace_distutils_spawn.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "replace deprecated ``distutils.spawn.find_executable`` with Ansible's ``get_bin_path`` in ``_search_executable`` function."

--- a/plugins/connection/libvirt_lxc.py
+++ b/plugins/connection/libvirt_lxc.py
@@ -26,7 +26,6 @@ options:
         - name: ansible_libvirt_lxc_host
 '''
 
-import distutils.spawn
 import os
 import os.path
 import subprocess
@@ -35,6 +34,7 @@ import traceback
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import shlex_quote
+from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils._text import to_bytes
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.utils.display import Display
@@ -62,10 +62,10 @@ class Connection(ConnectionBase):
         self._check_domain(self.lxc)
 
     def _search_executable(self, executable):
-        cmd = distutils.spawn.find_executable(executable)
-        if not cmd:
+        try:
+            return get_bin_path(executable)
+        except ValueError:
             raise AnsibleError("%s command not found in PATH") % executable
-        return cmd
 
     def _check_domain(self, domain):
         p = subprocess.Popen([self.virsh, '-q', '-c', 'lxc:///', 'dominfo', to_bytes(domain)],


### PR DESCRIPTION
distutils has been deprecated and will be removed from Python's stdlib
in Python 3.12 (see https://www.python.org/dev/peps/pep-0632/). This PR
replaces the use of deprecated ``distutils.spawn.find_executable`` with
Ansible's ``get_bin_path`` in ``_search_executable`` function.

See https://github.com/ansible-collections/overview/issues/45#issuecomment-999911221