### PR TITLE
Update doc elements to pass validate-modules test, remove usage of distutils.spawn

### DIFF
--- a/changelogs/fragments/114_replace_distutils_spawn.yml
+++ b/changelogs/fragments/114_replace_distutils_spawn.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "replace deprecated ``distutils.spawn.find_executable`` with Ansible's ``get_bin_path`` in ``_search_executable`` function."

--- a/plugins/connection/libvirt_lxc.py
+++ b/plugins/connection/libvirt_lxc.py
@@ -26,7 +26,6 @@ options:
         - name: ansible_libvirt_lxc_host
 '''
 
-import distutils.spawn
 import os
 import os.path
 import subprocess
@@ -35,6 +34,7 @@ import traceback
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import shlex_quote
+from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils._text import to_bytes
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.utils.display import Display
@@ -62,10 +62,10 @@ class Connection(ConnectionBase):
         self._check_domain(self.lxc)
 
     def _search_executable(self, executable):
-        cmd = distutils.spawn.find_executable(executable)
-        if not cmd:
+        try:
+            return get_bin_path(executable)
+        except ValueError:
             raise AnsibleError("%s command not found in PATH") % executable
-        return cmd
 
     def _check_domain(self, domain):
         p = subprocess.Popen([self.virsh, '-q', '-c', 'lxc:///', 'dominfo', to_bytes(domain)],

--- a/plugins/connection/libvirt_lxc.py
+++ b/plugins/connection/libvirt_lxc.py
@@ -11,8 +11,8 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 author:
-    - Michael Scherer <misc@zarb.org>
-connection: community.libvirt.libvirt_lxc
+    - Michael Scherer (@mscherer) <misc@zarb.org>
+name: libvirt_lxc
 short_description: Run tasks in lxc containers via libvirt
 description:
     - Run commands or put/fetch files to an existing lxc container using libvirt.

--- a/plugins/connection/libvirt_qemu.py
+++ b/plugins/connection/libvirt_qemu.py
@@ -11,8 +11,8 @@ __metaclass__ = type
 DOCUMENTATION = """
 ---
 author:
-    - Jesse Pretorius <jesse@odyssey4.me>
-connection: community.libvirt.libvirt_qemu
+    - Jesse Pretorius (@odyssey4me) <jesse@odyssey4.me>
+name: libvirt_qemu
 short_description: Run tasks on libvirt/qemu virtual machines
 description:
     - Run commands or put/fetch files to libvirt/qemu virtual machines using the qemu agent API.
@@ -22,7 +22,7 @@ notes:
     - Requires access to the qemu-ga commands guest-exec, guest-exec-status, guest-file-close, guest-file-open, guest-file-read, guest-file-write.
 extends_documentation_fragment:
     - community.libvirt.requirements
-version_added: "2.10"
+version_added: "2.10.0"
 options:
   remote_addr:
     description: Virtual machine name.

--- a/plugins/inventory/libvirt.py
+++ b/plugins/inventory/libvirt.py
@@ -1,9 +1,9 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = r'''
 name: libvirt
-plugin_type: inventory
 extends_documentation_fragment:
     - constructed
     - community.libvirt.requirements
@@ -11,8 +11,8 @@ short_description: Libvirt inventory source
 description:
     - Get libvirt guests in an inventory source.
 author:
-    - Dave Olsthoorn <dave@bewaar.me>
-version_added: "2.10"
+    - Dave Olsthoorn (@daveol) <dave@bewaar.me>
+version_added: "2.10.0"
 options:
     plugin:
         description: Token that ensures this is a source file for the 'libvirt' plugin.


### PR DESCRIPTION
This PR also merges in the changes from #114.

It fixes two issues relating to failing pipelines

### validate-modules

ansible-test's validate-modules sanity test was extended to also
validate the documentation (and thus configuration) for (documentable)
plugins. This introduced a schema which required updating of
documentation in order for the test to pass.

See https://github.com/ansible/ansible/pull/71734
See https://github.com/ansible-collections/news-for-maintainers/issues/9

Failing test:

```
$ ansible-test sanity --test validate-modules
Running sanity test "validate-modules"
ERROR: Found 9 validate-modules issue(s) which need to be resolved:
ERROR: plugins/connection/libvirt_lxc.py:0:0: invalid-documentation: DOCUMENTATION.author: Invalid author for dictionary value @ data['author']. Got ['Michael Scherer <***>']
ERROR: plugins/connection/libvirt_lxc.py:0:0: invalid-documentation: DOCUMENTATION.connection: extra keys not allowed @ data['connection']. Got 'community.libvirt.libvirt_lxc'
ERROR: plugins/connection/libvirt_lxc.py:0:0: invalid-documentation: DOCUMENTATION.name: required key not provided @ data['name']. Got None
ERROR: plugins/connection/libvirt_qemu.py:0:0: invalid-documentation: DOCUMENTATION.author: Invalid author for dictionary value @ data['author']. Got ['Jesse Pretorius <***>']
ERROR: plugins/connection/libvirt_qemu.py:0:0: invalid-documentation: DOCUMENTATION.connection: extra keys not allowed @ data['connection']. Got 'community.libvirt.libvirt_qemu'
ERROR: plugins/connection/libvirt_qemu.py:0:0: invalid-documentation: DOCUMENTATION.name: required key not provided @ data['name']. Got None
ERROR: plugins/inventory/libvirt.py:0:0: invalid-documentation: DOCUMENTATION.author: Invalid author for dictionary value @ data['author']. Got ['Dave Olsthoorn <***>']
ERROR: plugins/inventory/libvirt.py:0:0: invalid-documentation: DOCUMENTATION.plugin_type: extra keys not allowed @ data['plugin_type']. Got 'inventory'
ERROR: plugins/inventory/libvirt.py:0:0: missing-gplv3-license: GPLv3 license header not found in the first 20 lines of the module
See documentation for help: https://docs.ansible.com/ansible-core/devel/dev_guide/testing/sanity/validate-modules.html
ERROR: The 1 sanity test(s) listed below (out of 1) failed. See error output above for details.
validate-modules
```

### distutils

This is also merged with https://github.com/ansible-collections/community.libvirt/pull/114 

distutils has been deprecated and will be removed from Python's stdlib
in Python 3.12 (see https://www.python.org/dev/peps/pep-0632/). This PR
replaces the use of deprecated ``distutils.spawn.find_executable`` with
Ansible's ``get_bin_path`` in ``_search_executable`` function.

See https://github.com/ansible-collections/overview/issues/45#issuecomment-999911221
