### PR TITLE
CI: update test envs for devel

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -126,16 +126,16 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 34
-              test: fedora34
             - name: Fedora 35
               test: fedora35
+            - name: Fedora 36
+              test: fedora36
             - name: openSUSE 15 py3
               test: opensuse15
-            - name: Ubuntu 18.04
-              test: ubuntu1804
             - name: Ubuntu 20.04
               test: ubuntu2004
+            - name: Ubuntu 22.04
+              test: ubuntu2204
 
   - stage: Docker_2_13
     displayName: Docker 2.13
@@ -267,12 +267,14 @@ stages:
           targets:
             - name: RHEL 7.9
               test: rhel/7.9
-            - name: RHEL 8.5
-              test: rhel/8.5
+            - name: RHEL 8.6
+              test: rhel/8.6
+            - name: RHEL 9.0
+              test: rhel/9.0
             - name: FreeBSD 12.3
               test: freebsd/12.3
-            - name: FreeBSD 13.0
-              test: freebsd/13.0
+            - name: FreeBSD 13.1
+              test: freebsd/13.1
 
   - stage: Remote_2_13
     displayName: Remote 2.13

--- a/tests/integration/targets/virt_net/vars/RedHat-9.yml
+++ b/tests/integration/targets/virt_net/vars/RedHat-9.yml
@@ -1,0 +1,6 @@
+---
+virt_net_packages:
+  - libvirt
+  - libvirt-daemon
+  - python3-libvirt
+  - python3-lxml

--- a/tests/integration/targets/virt_pool/vars/RedHat-9.yml
+++ b/tests/integration/targets/virt_pool/vars/RedHat-9.yml
@@ -1,0 +1,9 @@
+---
+# RHEL 8/CentOS 8 only provides python-libvirt package for the default Python
+ansible_python_interpreter: /usr/libexec/platform-python
+
+virt_pool_packages:
+  - libvirt
+  - libvirt-daemon
+  - python3-libvirt
+  - python3-lxml


### PR DESCRIPTION
This change removes the following from devel testing:
- Fedora 34
- FreeBSD 13.0
- RHEL 8.5
- Ubuntu 18.04

This change adds the following from devel testing:
- Fedora 36
- FreeBSD 13.1
- RHEL 8.6
- RHEL 9.0
- Ubuntu 22.04

See https://github.com/ansible-collections/news-for-maintainers/issues/17
