### PR TITLE
Make path optional in virt_pool facts

### DIFF
--- a/changelogs/fragments/virt_pool_no_path.yml
+++ b/changelogs/fragments/virt_pool_no_path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - virt_pool - crashed out if pool didn't contain a target path. Fix allows this not to be set. (https://github.com/ansible-collections/community.libvirt/issues/129).

--- a/plugins/modules/virt_pool.py
+++ b/plugins/modules/virt_pool.py
@@ -335,7 +335,11 @@ class LibvirtConnection(object):
 
     def get_path(self, entryid):
         xml = etree.fromstring(self.find_entry(entryid).XMLDesc(0))
-        return xml.xpath('/pool/target/path')[0].text
+        try:
+            result = xml.xpath('/pool/target/path')[0].text
+        except Exception:
+            raise ValueError('Target path not specified')
+        return result
 
     def get_type(self, entryid):
         xml = etree.fromstring(self.find_entry(entryid).XMLDesc(0))
@@ -496,7 +500,6 @@ class VirtStoragePool(object):
                 results[entry]["autostart"] = self.conn.get_autostart(entry)
                 results[entry]["persistent"] = self.conn.get_persistent(entry)
                 results[entry]["state"] = self.conn.get_status(entry)
-                results[entry]["path"] = self.conn.get_path(entry)
                 results[entry]["type"] = self.conn.get_type(entry)
                 results[entry]["uuid"] = self.conn.get_uuid(entry)
                 if self.conn.find_entry(entry).isActive():
@@ -506,6 +509,11 @@ class VirtStoragePool(object):
                         results[entry]["volumes"].append(volume)
                 else:
                     results[entry]["volume_count"] = -1
+
+                try:
+                    results[entry]["path"] = self.conn.get_path(entry)
+                except ValueError:
+                    pass
 
                 try:
                     results[entry]["host"] = self.conn.get_host(entry)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix for #129, allows target path to be an optional fact

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
virt_pool (facts)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
