### PR TITLE
virt_pool: replace functions listStoragePools and listDefinedStoragePools

### DIFF
--- a/changelogs/fragments/134_virt_pool_replace_functions_listStoragePools.yml
+++ b/changelogs/fragments/134_virt_pool_replace_functions_listStoragePools.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - virt_pool - replace discouraged functions ``listStoragePools`` and ``listDefinedStoragePools`` with ``listAllStoragePools`` to fix potential race conditions (https://github.com/ansible-collections/community.libvirt/pull/134).

--- a/plugins/modules/virt_pool.py
+++ b/plugins/modules/virt_pool.py
@@ -222,17 +222,8 @@ class LibvirtConnection(object):
     def find_entry(self, entryid):
         # entryid = -1 returns a list of everything
 
-        results = []
-
-        # Get active entries
-        for name in self.conn.listStoragePools():
-            entry = self.conn.storagePoolLookupByName(name)
-            results.append(entry)
-
-        # Get inactive entries
-        for name in self.conn.listDefinedStoragePools():
-            entry = self.conn.storagePoolLookupByName(name)
-            results.append(entry)
+        # Get all entries
+        results = self.conn.listAllStoragePools()
 
         if entryid == -1:
             return results


### PR DESCRIPTION
##### SUMMARY
According to the libvirt storage API reference, the functions

- listStoragePools (virConnectListStoragePools)
- listDefinedStoragePools (virConnectListDefinedStoragePools)

should not be used anymore: "The use of this function is discouraged.
Instead, use virConnectListAllStoragePools()" ... "This API solves the
race inherent between virConnectListStoragePools and
virConnectListDefinedStoragePools."

Source:
https://libvirt.org/html/libvirt-libvirt-storage.html#virConnectListAllStoragePools

Examples:
- get ALL  pools with listAllStoragePools()
- get active pools with listAllStoragePools(2)
- get inactive pools with listAllStoragePools(1)

##### Compatibility / Risk:
The function "virConnectListAllStoragePools()" appeared in version
0.10.2 which was released in 2012. It seems rather unlikely that
somebody is still using an older unsupported libvirt version, so the
risk should be rather low.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
virt_pool

##### ADDITIONAL INFORMATION
My tests confirm that the bugfix works as expected. It does not change the output of virt_pool with facts and info compared to the old functions.

Below is a sample output: (some sensitive details are hidden by xxx):
```paste below
$ ansible -b -m virt_pool -a "command=facts" xxx
xxx | SUCCESS => {
    "ansible_facts": {
        "ansible_libvirt_pools": {
            "default": {
                "autostart": "yes",
                "path": "/var/lib/libvirt/images",
                "persistent": "yes",
                "size_available": "1227565760512",
                "size_total": "1967453855744",
                "size_used": "739888095232",
                "state": "active",
                "status": "running",
                "type": "dir",
                "uuid": "9ccab948-309a-4b68-8222-d15dd104e64b",
                "volume_count": 10,
                "volumes": [
                    "xxxxx.qcow2",
                    "xxxxxx.qcow2",
                    "xxxxxxx-1.qcow2",
                    "..."
                ]
            },
            "xxx": {
                "autostart": "yes",
                "host": "xxx",
                "persistent": "yes",
                "size_available": "xxx",
                "size_total": "xxx",
                "size_used": "xxx",
                "state": "active",
                "status": "running",
                "type": "rbd",
                "uuid": "59bf7e80-8bf8-4dd7-a2da-7b660e9f628f",
                "volume_count": 8,
                "volumes": [
                    "xxxxx.raw",
                    "xxxxxxxxx.raw",
                    "xxxxx.raw",
                    "..."
                ]
            }
        }
    },
    "changed": false
}
```
