### PR TITLE
Replace discouraged function listVolumes

### DIFF
--- a/changelogs/fragments/135_virt_pool_replace_function_listVolumes.yml
+++ b/changelogs/fragments/135_virt_pool_replace_function_listVolumes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - virt_pool - replace discouraged function ``listAllVolumes`` with ``listAllVolumes`` to fix potential race conditions (https://github.com/ansible-collections/community.libvirt/pull/135).

--- a/plugins/modules/virt_pool.py
+++ b/plugins/modules/virt_pool.py
@@ -287,7 +287,7 @@ class LibvirtConnection(object):
         return self.find_entry(entryid).numOfVolumes()
 
     def get_volume_names(self, entryid):
-        return self.find_entry(entryid).listVolumes()
+        return self.find_entry(entryid).listAllVolumes()
 
     def get_devices(self, entryid):
         xml = etree.fromstring(self.find_entry(entryid).XMLDesc(0))
@@ -497,7 +497,7 @@ class VirtStoragePool(object):
                     results[entry]["volume_count"] = self.conn.get_volume_count(entry)
                     results[entry]["volumes"] = list()
                     for volume in self.conn.get_volume_names(entry):
-                        results[entry]["volumes"].append(volume)
+                        results[entry]["volumes"].append(volume.name())
                 else:
                     results[entry]["volume_count"] = -1
 


### PR DESCRIPTION
This PR is similar to #134.

##### SUMMARY
According to the libvirt storage API reference, the function

- listVolumes (virStoragePoolListVolumes)

should not be used anymore: "The use of this
function is discouraged. Instead, use virStoragePoolListAllVolumes()."

Source:
https://libvirt.org/html/libvirt-libvirt-storage.html#virStoragePoolListVolumes

#### Compatibility / Risk:
The function "virStoragePoolListAllVolumes()" appeared in version
0.10.2 which was released in 2012. It seems rather unlikely that
somebody is still using an older unsupported libvirt version, so the
risk should be rather low.

Source:
https://libvirt.org/hvsupport.html#virStorageDriver

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
libvirt_pool

##### ADDITIONAL INFORMATION
My tests confirm that the bugfix works as expected. It does not change the output of virt_pool with facts and info compared to the old function.