### PR TITLE
Fix virt module to undefine a domain with nvram or other metadata

### DIFF
--- a/changelogs/fragments/136_fix_undefine_nvram.yml
+++ b/changelogs/fragments/136_fix_undefine_nvram.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - virt - fix virt module to undefine a domain with nvram, managed_save, snapshot_metadata or checkpoints_metadata (https://github.com/ansible-collections/community.libvirt/issues/40).


### PR DESCRIPTION
##### SUMMARY
Fixes #40

Libvirt function `undefine()` is not able to delete nvram or other
metadata. Therefore it is replaced with `undefineFlags()` which is able to
handle it by using flags.

All possible flags are listed in 'ENTRY_UNDEFINE_FLAGS_MAP'. Integer 23
makes `undefine` successful in all cases (1 + 2 + 4 + 16).

Source:
https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainUndefineFlags

The flags `nvram`(4) and `keep_nvram`(8) are mutually exclusive.

To control the metadata handling during `undefine`, two new options
`force` and `flags` are introduced including documentation and examples.

#### Compatibility / Risk:
The function `undefineFlags()` appeared in libvirt version 0.9.4 which was
release in 2011. It seems rather unlikely that somebody is still using
an older unsupported libvirt version. Additionally, if none of the new
module options are provided, then it behaves as before and maintains
backward compatibility, means the overall risk of this commit should be
rather low.

Source:
https://libvirt.org/hvsupport.html#virHypervisorDriver

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
virt

##### ADDITIONAL INFORMATION
My tests confirm that the bugfix works as expected, like `undefine` a qemu guest with UEFI nvram or a qemu guest with BIOS. Also other commands are still working, like `start`, `shutdown` or `destroy`.

ansible adhoc command:
```paste below
$ ansible -b -m community.libvirt.virt -a "name=guest99 command=undefine force=true" host99
```