### PR TITLE
CI: remove f35 from devel

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -126,8 +126,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 35
-              test: fedora35
             - name: Fedora 36
               test: fedora36
             - name: openSUSE 15 py3
@@ -149,6 +147,8 @@ stages:
               test: centos7
             - name: Fedora 34
               test: fedora34
+            - name: Fedora 35
+              test: fedora35
             - name: openSUSE 15 py2
               test: opensuse15py2
             - name: openSUSE 15 py3

--- a/plugins/inventory/libvirt.py
+++ b/plugins/inventory/libvirt.py
@@ -160,6 +160,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 )
 
                 # This needs the guest powered on, 'qemu-guest-agent' installed and the org.qemu.guest_agent.0 channel configured.
+                domain_guestInfo = ''
                 try:
                     # type==0 returns all types (users, os, timezone, hostname, filesystem, disks, interfaces)
                     domain_guestInfo = domain.guestInfo(types=0)
@@ -173,6 +174,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                     )
 
                 # This needs the guest powered on, 'qemu-guest-agent' installed and the org.qemu.guest_agent.0 channel configured.
+                domain_interfaceAddresses = ''
                 try:
                     domain_interfaceAddresses = domain.interfaceAddresses(source=libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT)
                 except libvirt.libvirtError as e:


### PR DESCRIPTION
Fedora 35 is deprecated from devel, this commit removes it from devel
and adds it to Docker 2_13 so that it continues to be tested.