### PR TITLE
doc: set booleans to true/false for consistency

### DIFF
--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -33,11 +33,11 @@ options:
             - Enforce an action.
             - Currently only implemented with command C(undefine).
               This option can be used instead of providing all C(flags).
-              If C(yes), C(undefine) removes also any related nvram or other metadata, if existing.
-              If C(no) or not set, C(undefine) executes only if there is no nvram or other metadata existing.
+              If C(true), C(undefine) removes also any related nvram or other metadata, if existing.
+              If C(false) or not set, C(undefine) executes only if there is no nvram or other metadata existing.
               Otherwise the task fails and the guest is kept defined without change.
-              C(yes) and option C(flags) should not be provided together. In this case
-              C(undefine) ignores C(yes), considers only C(flags) and issues a warning.
+              C(true) and option C(flags) should not be provided together. In this case
+              C(undefine) ignores C(true), considers only C(flags) and issues a warning.
         type: bool
 extends_documentation_fragment:
     - community.libvirt.virt.options_uri
@@ -81,14 +81,14 @@ EXAMPLES = '''
 - name: Set autostart for a VM
   community.libvirt.virt:
     name: foo
-    autostart: yes
+    autostart: true
 
 # Defining a VM and making is autostart with host. VM will be off after this task
 - name: Define vm from xml and set autostart
   community.libvirt.virt:
     command: define
     xml: "{{ lookup('template', 'vm_template.xml.j2') }}"
-    autostart: yes
+    autostart: true
 
 # Undefine VM only, if it has no existing nvram or other metadata
 - name: Undefine qemu VM
@@ -99,7 +99,7 @@ EXAMPLES = '''
 - name: "Undefine qemu VM with force"
   community.libvirt.virt:
     name: foo
-    force: yes
+    force: true
 
 # Undefine VM and remove all of its specified metadata specified
 # Result would the same as with force=true

--- a/plugins/modules/virt_net.py
+++ b/plugins/modules/virt_net.py
@@ -109,12 +109,12 @@ EXAMPLES = '''
 
 - name: Ensure that a given network will be started at boot
   community.libvirt.virt_net:
-    autostart: yes
+    autostart: true
     name: br_nat
 
 - name: Disable autostart for a given network
   community.libvirt.virt_net:
-    autostart: no
+    autostart: false
     name: br_nat
 
 - name: Add a new host in the dhcp pool

--- a/plugins/modules/virt_pool.py
+++ b/plugins/modules/virt_pool.py
@@ -124,12 +124,12 @@ EXAMPLES = '''
 
 - name: Ensure that a given pool will be started at boot
   community.libvirt.virt_pool:
-    autostart: yes
+    autostart: true
     name: vms
 
 - name: Disable autostart for a given pool
   community.libvirt.virt_pool:
-    autostart: no
+    autostart: false
     name: vms
 '''
 


### PR DESCRIPTION
The Ansible Steering Committee voted to make all docs refer to booleans as true/false, as there is currently a mix of
yes/no/True/False/true/false.

See https://github.com/ansible-community/community-topics/issues/116

Fixes #139