### PR TITLE
Virt define improvements

### DIFF
--- a/changelogs/fragments/142_virt_define_improvements.yml
+++ b/changelogs/fragments/142_virt_define_improvements.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - virt - support ``--diff`` for ``define`` command (https://github.com/ansible-collections/community.libvirt/pull/142/).
+  - virt - add `mutate_flags` parameter to enable XML mutation (add UUID, MAC addresses from existing domain) (https://github.com/ansible-collections/community.libvirt/pull/142/).

--- a/plugins/doc_fragments/virt.py
+++ b/plugins/doc_fragments/virt.py
@@ -65,3 +65,24 @@ options:
       - Must be raw XML content using C(lookup). XML cannot be reference to a file.
     type: str
     """
+
+    OPTIONS_MUTATE_FLAGS = r"""
+options:
+  mutate_flags:
+    description:
+      - For each mutate_flag, we will modify the given XML in some way
+      - ADD_UUID will add an existing domain's UUID to the xml if it's missing
+      - ADD_MAC_ADDRESSES will look up interfaces in the existing domain with a
+        matching alias and copy the MAC address over. The matching interface
+        doesn't need to be of the same type or source network.
+      - ADD_MAC_ADDRESSES_FUZZY will try to match incoming interfaces with
+        interfaces of the existing domain sharing the same type and source
+        network/device. It may not always result in the expected outcome,
+        particularly if a domain has multiple interface attached to the same
+        host device and only some of those devices have <mac>s.
+        Use caution, do some testing for your particular use-case!
+    choices: [ ADD_UUID, ADD_MAC_ADDRESSES, ADD_MAC_ADDRESSES_FUZZY ]
+    type: list
+    elements: str
+    default: ['ADD_UUID']
+    """


### PR DESCRIPTION
##### SUMMARY
This pull request effectively rewrites how domains are defined.

To summarize its changes:
- Diff info is now supplied, showing the changes between previously and
  newly defined domain XML.
- If a domain with the same name already exists and the incoming UUID is
  missing, apply the existing UUID to the incoming XML.
- If a UUID is defined in the incoming XML and it doesn't match that of
  an existing domain with the same name, exit with an error
- For any incoming XML <interface> missing a <mac> element, we will
  attempt to fetch MAC of the matching interface from the existing
  domain's XML

##### ISSUE TYPE
- Improvement Pull Request

##### COMPONENT NAME
virt

##### ADDITIONAL INFORMATION

Before these changes, if a definition was given without a UUID, the
appropriate domain would be created with a libvirt-generated UUID. If
the definition was modified (with UUID still left out), the module would
quietly exit with `changes: False` and make no changes (masking a
libvirt error that a domain with the same name already existed).

If a UUID was given, the module would work (mostly) as expected and
update the domain's definition. However, if the <uuid> did not match the
<uuid> of an existing domain with the same name, the module would
quietly exit without making changes again.

I say (mostly) as expected, because it was still possible to create
non-idempotent XML definitions. For example, if network interface MAC
addresses were left out of the XML definition, libvirt would generate
entirely new ones; probably not what most users would expect.