### PR TITLE
QEMU connection plugin warning: improperly configured remote target

### DIFF
--- a/changelogs/fragments/147_fix_qemu_remote_target_warning.yml
+++ b/changelogs/fragments/147_fix_qemu_remote_target_warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - libvirt_qemu - connection plugin threw a warning about an improperly configured remote target. Fix adds `inventory_hostname` to `options.remote_addr.vars` (https://github.com/ansible-collections/community.libvirt/pull/147/).

--- a/changelogs/fragments/147_fix_qemu_remote_target_warning.yml
+++ b/changelogs/fragments/147_fix_qemu_remote_target_warning.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - libvirt_qemu - connection plugin threw a warning about an improperly configured remote target. Fix adds `inventory_hostname` to `options.remote_addr.vars` (https://github.com/ansible-collections/community.libvirt/pull/147/).
+  - libvirt_qemu - connection plugin threw a warning about an improperly configured remote target. Fix adds `inventory_hostname` to `options.remote_addr.vars` (https://github.com/ansible-collections/community.libvirt/pull/147).

--- a/plugins/connection/libvirt_qemu.py
+++ b/plugins/connection/libvirt_qemu.py
@@ -29,6 +29,7 @@ options:
     default: inventory_hostname
     vars:
       - name: ansible_host
+      - name: inventory_hostname
   executable:
     description:
       - Shell to use for execution inside container.


### PR DESCRIPTION
##### SUMMARY
Fixes a warning that appears on every task about the `community.libvirt.libvirt_qemu` connection plugin having an improperly configured remote target value.
```
[WARNING]: The "community.libvirt.libvirt_qemu" connection plugin has an improperly configured remote target value, forcing "inventory_hostname" templated value instead of the string
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.libvirt.libvirt_qemu

##### ADDITIONAL INFORMATION
This fix is similar to the one found at [containers/ansible-podman-collections #506](https://github.com/containers/ansible-podman-collections/pull/506).

**Before:**
```
❯ ansible-playbook -i virt1_inventory.yml test.yml
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details

PLAY [VM Main Playbook] ********************************************************

TASK [Gathering Facts] *********************************************************
[WARNING]: The "community.libvirt.libvirt_qemu" connection plugin has an improperly configured remote target value, forcing "inventory_hostname" templated value instead of the string
[WARNING]: Platform linux on host gitlab is using the discovered Python interpreter at /usr/bin/python3.9, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-core/2.14/reference_appendices/interpreter_discovery.html for more information.
ok: [gitlab]

TASK [Get roles from instance metadata] ****************************************
[WARNING]: The "community.libvirt.libvirt_qemu" connection plugin has an improperly configured remote target value, forcing "inventory_hostname" templated value instead of the string
changed: [gitlab]

TASK [Sanitize output into a list] *********************************************
[WARNING]: The "community.libvirt.libvirt_qemu" connection plugin has an improperly configured remote target value, forcing "inventory_hostname" templated value instead of the string
ok: [gitlab]

```

**After**
```
❯ ansible-playbook -i virt1_inventory.yml test.yml
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details

PLAY [VM Main Playbook] ********************************************************

TASK [Gathering Facts] *********************************************************
[WARNING]: Platform linux on host gitlab is using the discovered Python interpreter at /usr/bin/python3.9, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-core/2.14/reference_appendices/interpreter_discovery.html for more information.
ok: [gitlab]

TASK [Get roles from instance metadata] ****************************************
changed: [gitlab]

TASK [Sanitize output into a list] *********************************************
ok: [gitlab]
```
