### PR TITLE
CI: update RHEL for remote devel

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -215,10 +215,10 @@ stages:
           targets:
             - name: RHEL 7.9
               test: rhel/7.9
-            - name: RHEL 8.7
-              test: rhel/8.7
-            - name: RHEL 9.1
-              test: rhel/9.1
+            - name: RHEL 8.8
+              test: rhel/8.8
+            - name: RHEL 9.2
+              test: rhel/9.2
             - name: FreeBSD 12.4
               test: freebsd/12.4
             - name: FreeBSD 13.1


### PR DESCRIPTION
Deprecate RHEL 8.7 and 9.1 and add 8.8 and 9.2 to remote devel.

See https://github.com/ansible-collections/news-for-maintainers/issues/47