### PR TITLE
ci: bump devel tests to freebsd 13.2, fix sanity test and linting

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -219,8 +219,8 @@ stages:
               test: rhel/8.8
             - name: RHEL 9.2
               test: rhel/9.2
-            - name: FreeBSD 13.1
-              test: freebsd/13.1
+            - name: FreeBSD 13.2
+              test: freebsd/13.2
 
   - stage: Remote_2_15
     displayName: Remote 2.15
@@ -262,8 +262,8 @@ stages:
           targets:
             - name: RHEL 8.5
               test: rhel/8.5
-            - name: FreeBSD 13.0
-              test: freebsd/13.0
+            - name: FreeBSD 13.1
+              test: freebsd/13.1
 
   - stage: Remote_2_12
     displayName: Remote 2.12

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,3 +1,2 @@
 tests/utils/shippable/timing.py shebang
-tests/utils/shippable/check_matrix.py replace-urlopen
 tests/unit/compat/builtins.py pylint:unused-import

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -30,7 +30,7 @@ class DictDataLoader(DataLoader):
 
     def __init__(self, file_mapping=None):
         file_mapping = {} if file_mapping is None else file_mapping
-        assert type(file_mapping) == dict
+        assert type(file_mapping) is dict
 
         super(DictDataLoader, self).__init__()
 


### PR DESCRIPTION
bump devel tests to freebsd 13.2

The sanity test 'replace-urlopen' does not test path 'tests/utils/shippable/check_matrix.py', remove this.