### PR TITLE
fix resolve tilde in file paths (fixes #161)

### DIFF
--- a/changelogs/fragments/161_fix_resolve_tilde.yml
+++ b/changelogs/fragments/161_fix_resolve_tilde.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - libvirt_qemu - fix path resolution of tilde (~) used to represent remote user's homedir

--- a/plugins/connection/libvirt_qemu.py
+++ b/plugins/connection/libvirt_qemu.py
@@ -157,10 +157,10 @@ class Connection(ConnectionBase):
         self._user_homedir = to_text(stdout).strip()
         return self._user_homedir
 
-    def _resolve_tilde(self,string):
+    def _resolve_tilde(self, string):
         """ resolve file paths or commands that begin with '~/' to the remote user's homedir """
-        if re.search(r"~\/",string):
-            return re.sub(r"~\/", self.user_homedir + r"/",string)
+        if re.search(r"~\/", string):
+            return re.sub(r"~\/", self.user_homedir + r"/", string)
         return string
 
     def exec_command(self, cmd, in_data=None, sudoable=True):
@@ -170,7 +170,7 @@ class Connection(ConnectionBase):
         self._display.vvv(u"EXEC {0}".format(cmd), host=self._host)
 
         cmd_args_list = shlex.split(to_native(cmd, errors='surrogate_or_strict'))
-        cmd_args_list = list(map(self._resolve_tilde,cmd_args_list))
+        cmd_args_list = list(map(self._resolve_tilde, cmd_args_list))
 
         if getattr(self._shell, "_IS_WINDOWS", False):
             # Become method 'runas' is done in the wrapper that is executed,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The libvirt_qemu connection module uses QEMU guest agent to copy files
and run commands on the remote host. Ansible uses the '\~/' symbolic path
to the user's home directory for many commands and file paths.
Unfortunately, since QEMU guest agent doesn't run in a shell, it doesn't
resolve the '\~/' path to the user's homedir.

Instead, the Ansible paths end up at '/\~/' in the remote host. This
breaks some assumptions for some modules about the path to the Ansible
files. Some modules use the resolved homedir path and fail to find any
files in that location.

This fix first resolves the remote user homedir with a QEMU guest
command, caches the result, and then replaces '\~/' found in any command
or remote file paths with the resolved absolute path to the user's
homedir.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.libvirt.libvirt_qemu connection plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I've tested this patch with playbooks that use many different Ansible modules and it seems to work in all the ones I tested, including the copy module that was having issues in #161.
<!--- Paste verbatim command output below, e.g. before and after your change -->

