### PR TITLE
CI: add support for 2.16

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -56,6 +56,18 @@ stages:
             - name: Units
               test: 'devel/units/1'
 
+  - stage: Ansible_2_16
+    displayName: Sanity & Units 2.16
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.16/sanity/1'
+            - name: Units
+              test: '2.16/units/1'
+
   - stage: Ansible_2_15
     displayName: Sanity & Units 2.15
     dependsOn: []
@@ -112,6 +124,25 @@ stages:
       - template: templates/matrix.yml
         parameters:
           testFormat: devel/linux/{0}/1
+          targets:
+            - name: CentOS 7
+              test: centos7
+            - name: Fedora 38
+              test: fedora38
+            - name: openSUSE 15 py3
+              test: opensuse15
+            - name: Ubuntu 20.04
+              test: ubuntu2004
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+
+  - stage: Docker_2_16
+    displayName: Docker 2.16
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.16/linux/{0}/1
           targets:
             - name: CentOS 7
               test: centos7
@@ -222,6 +253,23 @@ stages:
             - name: FreeBSD 13.2
               test: freebsd/13.2
 
+  - stage: Remote_2_16
+    displayName: Remote 2.16
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: '2.16/{0}/1'
+          targets:
+            - name: RHEL 7.9
+              test: rhel/7.9
+            - name: RHEL 8.8
+              test: rhel/8.8
+            - name: RHEL 9.2
+              test: rhel/9.2
+            - name: FreeBSD 13.2
+              test: freebsd/13.2
+
   - stage: Remote_2_15
     displayName: Remote 2.15
     dependsOn: []
@@ -286,16 +334,19 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_16
       - Ansible_2_15
       - Ansible_2_14
       - Ansible_2_13
       - Ansible_2_12
       - Docker_devel
+      - Docker_2_16
       - Docker_2_15
       - Docker_2_14
       - Docker_2_13
       - Docker_2_12
       - Remote_devel
+      - Remote_2_16
       - Remote_2_15
       - Remote_2_14
       - Remote_2_13

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,2 @@
+tests/utils/shippable/timing.py shebang
+tests/unit/compat/builtins.py pylint:unused-import


### PR DESCRIPTION
With the release of 2.16, devel is now 2.17, so this change adds in support to test 2.16 specifically.

See https://github.com/ansible-collections/news-for-maintainers/issues/58