### PR TITLE
Add lxml Python dependency to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This collection is shipped with the `ansible` package.
 <!-- List any external resources the collection depends on, for example minimum versions of an OS, libraries, or utilities. Do not list other Ansible collections here. -->
 - python >= 2.6
 - [libvirt python bindings](https://pypi.org/project/libvirt-python/)
+- lxml
 
 ## Included content
 <!-- Galaxy will eventually list the module docs within the UI, but until that is ready, you may need to either describe your plugins etc here, or point to an external docsite to cover that information. -->

--- a/plugins/doc_fragments/requirements.py
+++ b/plugins/doc_fragments/requirements.py
@@ -11,4 +11,5 @@ options: {}
 requirements:
     - python >= 2.6
     - libvirt python bindings
+    - lxml
     """


### PR DESCRIPTION
fixes #165

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

lxml seems a requirement, and isn't explicitly stated, and isn't necessarily available by default.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
virt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See the linked issue.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
