### PR TITLE
ci: swap rhel 9.2 with 9.3

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -217,8 +217,8 @@ stages:
               test: rhel/7.9
             - name: RHEL 8.8
               test: rhel/8.8
-            - name: RHEL 9.2
-              test: rhel/9.2
+            - name: RHEL 9.3
+              test: rhel/9.3
             - name: FreeBSD 13.2
               test: freebsd/13.2
 


### PR DESCRIPTION
RHEL 9.2 has been deprecated from ansible-test and replaced with RHEL 9.3. This change applies this to the devel tests.