### PR TITLE
fix up CI pipeline

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -113,12 +113,8 @@ stages:
         parameters:
           testFormat: devel/linux/{0}/1
           targets:
-            - name: CentOS 7
-              test: centos7
-            - name: Fedora 38
-              test: fedora38
-            - name: openSUSE 15 py3
-              test: opensuse15
+            - name: Fedora 39
+              test: fedora39
             - name: Ubuntu 20.04
               test: ubuntu2004
             - name: Ubuntu 22.04
@@ -213,12 +209,8 @@ stages:
         parameters:
           testFormat: 'devel/{0}/1'
           targets:
-            - name: RHEL 7.9
-              test: rhel/7.9
-            - name: RHEL 8.8
-              test: rhel/8.8
-            - name: RHEL 9.2
-              test: rhel/9.2
+            - name: RHEL 9.3
+              test: rhel/9.3
             - name: FreeBSD 13.2
               test: freebsd/13.2
 
@@ -234,8 +226,8 @@ stages:
               test: rhel/9.1
             - name: RHEL 8.7
               test: rhel/8.7
-            - name: FreeBSD 13.1
-              test: freebsd/13.1
+            - name: FreeBSD 13.2
+              test: freebsd/13.2
 
   - stage: Remote_2_14
     displayName: Remote 2.14
@@ -249,8 +241,8 @@ stages:
               test: rhel/9.0
             - name: RHEL 8.6
               test: rhel/8.6
-            - name: FreeBSD 13.1
-              test: freebsd/13.1
+            - name: FreeBSD 13.2
+              test: freebsd/13.2
 
   - stage: Remote_2_13
     displayName: Remote 2.13

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -30,7 +30,7 @@ class DictDataLoader(DataLoader):
 
     def __init__(self, file_mapping=None):
         file_mapping = {} if file_mapping is None else file_mapping
-        assert type(file_mapping) is dict
+        assert isinstance(file_mapping, dict)
 
         super(DictDataLoader, self).__init__()
 

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -68,6 +68,7 @@ if [ "${SHIPPABLE_BUILD_ID:-}" ]; then
     SHIPPABLE_RESULT_DIR="$(pwd)/shippable"
     TEST_DIR="${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/libvirt"
     mkdir -p "${TEST_DIR}"
+    # shellcheck disable=SC2153
     cp -aT "${SHIPPABLE_BUILD_DIR}" "${TEST_DIR}"
     cd "${TEST_DIR}"
 else


### PR DESCRIPTION
Fix linting issues by swapping `type()` with `isinstance()` and ignoring
shellcheck SC2153 rule on `SHIPPABLE_BUILD_DIR`.

RHEL 9.2 has been deprecated from ansible-test and replaced with RHEL
9.3, see
https://forum.ansible.com/t/ansible-test-added-rhel-9-3-and-deprecated-rhel-9-2/2336/1.

Fedora 38 has been deprecated and swapped with 39, see
https://forum.ansible.com/t/ansible-test-added-fedora-39-and-deprecated-fedora-38/2440/1.

FreeBSD 13.1 has been deprecated and swapped with 13.2 in tests for 2.14
and 2.15, see
https://forum.ansible.com/t/ansible-test-ansible-core-2-14-and-2-15-updating-from-freebsd-13-1-to-13-2/2853/2.

Support for Python 2.7 and 3.6 has been dropped, so deprecate images, see
https://github.com/ansible-collections/news-for-maintainers/issues/60#issuecomment-1746173749.