### PR TITLE
ci: replace freebsd 13.2 with 13.3

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -56,6 +56,18 @@ stages:
             - name: Units
               test: 'devel/units/1'
 
+  - stage: Ansible_2_17
+    displayName: Sanity & Units 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.17/sanity/1'
+            - name: Units
+              test: '2.17/units/1'
+
   - stage: Ansible_2_16
     displayName: Sanity & Units 2.16
     dependsOn: []
@@ -124,6 +136,21 @@ stages:
       - template: templates/matrix.yml
         parameters:
           testFormat: devel/linux/{0}/1
+          targets:
+            - name: Fedora 39
+              test: fedora39
+            - name: Ubuntu 20.04
+              test: ubuntu2004
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+
+  - stage: Docker_2_17
+    displayName: Docker 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.17/linux/{0}/1
           targets:
             - name: Fedora 39
               test: fedora39
@@ -242,8 +269,21 @@ stages:
           targets:
             - name: RHEL 9.3
               test: rhel/9.3
-            - name: FreeBSD 13.2
-              test: freebsd/13.2
+            - name: FreeBSD 13.3
+              test: freebsd/13.3
+
+  - stage: Remote_2_17
+    displayName: Remote 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: '2.17/{0}/1'
+          targets:
+            - name: RHEL 9.3
+              test: rhel/9.3
+            - name: FreeBSD 13.3
+              test: freebsd/13.3
 
   - stage: Remote_2_16
     displayName: Remote 2.16
@@ -326,18 +366,21 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_17
       - Ansible_2_16
       - Ansible_2_15
       - Ansible_2_14
       - Ansible_2_13
       - Ansible_2_12
       - Docker_devel
+      - Docker_2_17
       - Docker_2_16
       - Docker_2_15
       - Docker_2_14
       - Docker_2_13
       - Docker_2_12
       - Remote_devel
+      - Remote_2_17
       - Remote_2_16
       - Remote_2_15
       - Remote_2_14

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,2 @@
+tests/utils/shippable/timing.py shebang
+tests/unit/compat/builtins.py pylint:unused-import

--- a/tests/unit/compat/mock.py
+++ b/tests/unit/compat/mock.py
@@ -64,8 +64,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             # newline that our naive format() added
             data_as_list[-1] = data_as_list[-1][:-1]
 
-        for line in data_as_list:
-            yield line
+        yield from data_as_list
 
     def mock_open(mock=None, read_data=''):
         """
@@ -93,8 +92,7 @@ if sys.version_info >= (3,) and sys.version_info < (3, 4, 4):
             if handle.readline.return_value is not None:
                 while True:
                     yield handle.readline.return_value
-            for line in _data:
-                yield line
+            yield from _data
 
         global file_spec
         if file_spec is None:


### PR DESCRIPTION
The devel version of ansible-test has been updated to include support for FreeBSD 13.3, so this change swaps out 13.2 accordingly.

See https://github.com/ansible-collections/news-for-maintainers/issues/67