### PR TITLE
CI: add support for 2.19

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -56,6 +56,18 @@ stages:
             - name: Units
               test: 'devel/units/1'
 
+  - stage: Ansible_2_18
+    displayName: Sanity & Units 2.18
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: Sanity
+              test: '2.18/sanity/1'
+            - name: Units
+              test: '2.18/units/1'
+
   - stage: Ansible_2_17
     displayName: Sanity & Units 2.17
     dependsOn: []
@@ -112,6 +124,19 @@ stages:
       - template: templates/matrix.yml
         parameters:
           testFormat: devel/linux/{0}/1
+          targets:
+            - name: Fedora 40
+              test: fedora40
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+
+  - stage: Docker_2_18
+    displayName: Docker 2.18
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.18/linux/{0}/1
           targets:
             - name: Fedora 40
               test: fedora40
@@ -200,6 +225,19 @@ stages:
             - name: FreeBSD 13.3
               test: freebsd/13.3
 
+  - stage: Remote_2_18
+    displayName: Remote 2.18
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: '2.18/{0}/1'
+          targets:
+            - name: RHEL 9.4
+              test: rhel/9.4
+            - name: FreeBSD 13.3
+              test: freebsd/13.3
+
   - stage: Remote_2_17
     displayName: Remote 2.17
     dependsOn: []
@@ -264,16 +302,19 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_18
       - Ansible_2_17
       - Ansible_2_16
       - Ansible_2_15
       - Ansible_2_14
       - Docker_devel
+      - Docker_2_18
       - Docker_2_17
       - Docker_2_16
       - Docker_2_15
       - Docker_2_14
       - Remote_devel
+      - Remote_2_18
       - Remote_2_17
       - Remote_2_16
       - Remote_2_15

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,0 +1,2 @@
+tests/utils/shippable/timing.py shebang
+tests/unit/compat/builtins.py pylint:unused-import


### PR DESCRIPTION
With the release of 2.18, devel is now 2.19, so this change adds in support to test 2.19 specifically.
