### PR TITLE
Implement --check support for the libvirt.virt module

### DIFF
--- a/changelogs/fragments/183-check-mode.yml
+++ b/changelogs/fragments/183-check-mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - virt - implement basic check mode functionality (https://github.com/ansible-collections/community.libvirt/issue/98)

--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -395,6 +395,9 @@ class Virt(object):
 
     def autostart(self, vmid, as_flag):
         self.conn = self.__get_conn()
+        if self.module.check_mode:
+            return self.conn.get_autostart(vmid) != as_flag
+
         # Change autostart flag only if needed
         if self.conn.get_autostart(vmid) != as_flag:
             self.conn.set_autostart(vmid, as_flag)
@@ -408,42 +411,51 @@ class Virt(object):
 
     def shutdown(self, vmid):
         """ Make the machine with the given vmid stop running.  Whatever that takes.  """
+        if self.module.check_mode:
+            return 0
         self.__get_conn()
         self.conn.shutdown(vmid)
         return 0
 
     def pause(self, vmid):
         """ Pause the machine with the given vmid.  """
-
+        if self.module.check_mode:
+            return 0
         self.__get_conn()
         return self.conn.suspend(vmid)
 
     def unpause(self, vmid):
         """ Unpause the machine with the given vmid.  """
-
+        if self.module.check_mode:
+            return 0
         self.__get_conn()
         return self.conn.resume(vmid)
 
     def create(self, vmid):
         """ Start the machine via the given vmid """
-
+        if self.module.check_mode:
+            return 0
         self.__get_conn()
         return self.conn.create(vmid)
 
     def start(self, vmid):
         """ Start the machine via the given id/name """
-
+        if self.module.check_mode:
+            return 0
         self.__get_conn()
         return self.conn.create(vmid)
 
     def destroy(self, vmid):
         """ Pull the virtual power from the virtual domain, giving it virtually no time to virtually shut down.  """
+        if self.module.check_mode:
+            return 0
         self.__get_conn()
         return self.conn.destroy(vmid)
 
     def undefine(self, vmid, flag):
         """ Stop a domain, and then wipe it from the face of the earth.  (delete disk/config file) """
-
+        if self.module.check_mode:
+            return 0
         self.__get_conn()
         return self.conn.undefine(vmid, flag)
 

--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -48,6 +48,10 @@ extends_documentation_fragment:
     - community.libvirt.virt.options_command
     - community.libvirt.virt.options_mutate_flags
     - community.libvirt.requirements
+attributes:
+    check_mode:
+        description: Supports check_mode.
+        support: full
 author:
     - Ansible Core Team
     - Michael DeHaan
@@ -842,6 +846,7 @@ def main():
             xml=dict(type='str'),
             mutate_flags=dict(type='list', elements='str', choices=MUTATE_FLAGS, default=['ADD_UUID']),
         ),
+        supports_check_mode=True
     )
 
     if not HAS_VIRT:

--- a/tests/integration/targets/virt/aliases
+++ b/tests/integration/targets/virt/aliases
@@ -1,0 +1,6 @@
+shippable/posix/group1
+skip/aix
+skip/freebsd
+skip/osx
+needs/privileged
+destructive

--- a/tests/integration/targets/virt/defaults/main.yml
+++ b/tests/integration/targets/virt/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+emulator_bin: /usr/bin/qemu-system-x86_64
+domain_info:
+  name: test_dom

--- a/tests/integration/targets/virt/tasks/define_check_mode.yml
+++ b/tests/integration/targets/virt/tasks/define_check_mode.yml
@@ -1,0 +1,102 @@
+---
+- name: "Determine QEMU version"
+  command: "{{ emulator_bin }} --version"
+  register: emulator_version_output
+
+- name: "Set QEMU version"
+  set_fact:
+    emulator_version: "{{ 0 | extract(emulator_version_output.stdout | regex_search('version (\\d+\\.\\d+)', '\\1')) }}"
+
+#
+# Define domain
+#
+- name: "Define {{ domain_info.name }} on check_mode(pre)"
+  community.libvirt.virt:
+    command: define
+    name: "{{ domain_info.name }}"
+    xml: '{{ lookup("template", "test_domain.xml.j2") }}'
+  register: result_pre
+  check_mode: true
+
+- name: "Define {{ domain_info.name }}"
+  community.libvirt.virt:
+    command: define
+    name: "{{ domain_info.name }}"
+    xml: '{{ lookup("template", "test_domain.xml.j2") }}'
+  register: result
+
+- name: "Define {{ domain_info.name }} on check_mode(post)"
+  community.libvirt.virt:
+    command: define
+    name: "{{ domain_info.name }}"
+    xml: '{{ lookup("template", "test_domain.xml.j2") }}'
+  register: result_post
+  check_mode: true
+
+- name: "Ensure the {{ domain_info.name }} has been defined"
+  assert:
+    that:
+      - result_pre is changed
+      - result is changed
+      - result_post is not changed
+      - result.created == domain_info.name
+
+#
+# Start domain
+#
+- name: "Start {{ domain_info.name }} on check_mode(pre)"
+  community.libvirt.virt:
+    state: running
+    name: "{{ domain_info.name }}"
+  register: result_pre
+  check_mode: true
+
+- name: "Start {{ domain_info.name }}"
+  community.libvirt.virt:
+    state: running
+    name: "{{ domain_info.name }}"
+  register: result
+
+- name: "Start {{ domain_info.name }} on check_mode(post}"
+  community.libvirt.virt:
+    state: running
+    name: "{{ domain_info.name }}"
+  register: result_post
+  check_mode: true
+
+- name: "Ensure the {{ domain_info.name }} has started"
+  assert:
+    that:
+      - result_pre is changed
+      - result is changed and result.msg == 0
+      - result_post is not changed
+
+#
+# Undefine domain
+#
+- name: Delete "{{ domain_info.name }} on check_mode(pre)"
+  community.libvirt.virt:
+    command: undefine
+    name: "{{ domain_info.name }}"
+  register: result_pre
+  check_mode: true
+
+- name: Delete "{{ domain_info.name }}"
+  community.libvirt.virt:
+    command: undefine
+    name: "{{ domain_info.name }}"
+  register: result
+
+- name: Delete "{{ domain_info.name }} on check_mode(post)"
+  community.libvirt.virt:
+    command: undefine
+    name: "{{ domain_info.name }}"
+  register: result_post
+  check_mode: true
+
+- name: "Ensure the {{ domain_info.name }} has been deleted"
+  assert:
+    that:
+      - result_pre is changed
+      - result is changed and result.command == 0
+      - result_post is not changed

--- a/tests/integration/targets/virt/tasks/main.yml
+++ b/tests/integration/targets/virt/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- include_vars: '{{ item }}'
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_version}}.yml"
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version}}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "default.yml"
+
+- block:
+    - name: Install libvirt packages
+      package:
+        name: "{{ virt_domain_packages }}"
+
+    - name: Start libvirt service
+      service:
+        name: libvirtd
+        state: started
+
+    - name: Test check mode for domain defines
+      import_tasks: define_check_mode.yml
+
+  always:
+    - name: Stop libvirt
+      service:
+        name: libvirtd
+        state: stopped
+
+    - name: Remove only the libvirt packages
+      package:
+        name: "{{ virt_domain_packages|select('match', '.*libvirt.*')|list }}"
+        state: absent

--- a/tests/integration/targets/virt/templates/test_domain.xml.j2
+++ b/tests/integration/targets/virt/templates/test_domain.xml.j2
@@ -1,0 +1,51 @@
+<domain type='qemu'>
+  <name>{{ domain_info['name'] }}</name>
+  <uuid>125388f2-6ab4-4343-a166-bad6ffad017e</uuid>
+  <memory unit='KiB'>4000768</memory>
+  <currentMemory unit='KiB'>4000000</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-{{ emulator_version }}'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <features>
+    <acpi/>
+    <apic/>
+    <pae/>
+  </features>
+  <cpu mode='custom' match='exact' check='none'>
+    <model fallback='forbid'>qemu64</model>
+  </cpu>
+  <clock offset='utc'>
+    <timer name='kvmclock' present='no'/>
+  </clock>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>restart</on_crash>
+  <devices>
+    <emulator>{{ emulator_bin }}</emulator>
+    <controller type='usb' index='0' model='piix3-uhci'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pci-root'/>
+    <controller type='pci' index='1' model='pci-bridge'>
+      <model name='pci-bridge'/>
+      <target chassisNr='1'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+    </controller>
+    <controller type='pci' index='2' model='pci-bridge'>
+      <model name='pci-bridge'/>
+      <target chassisNr='2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
+    </controller>
+    <controller type='pci' index='3' model='pci-bridge'>
+      <model name='pci-bridge'/>
+      <target chassisNr='3'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
+    </controller>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <audio id='1' type='none'/>
+    <memballoon model='none'/>
+  </devices>
+</domain>

--- a/tests/integration/targets/virt/vars/Debian.yml
+++ b/tests/integration/targets/virt/vars/Debian.yml
@@ -1,0 +1,6 @@
+---
+virt_domain_packages:
+  - libvirt-daemon
+  - libvirt-daemon-system
+  - python-libvirt
+  - python-lxml

--- a/tests/integration/targets/virt/vars/Fedora.yml
+++ b/tests/integration/targets/virt/vars/Fedora.yml
@@ -1,0 +1,6 @@
+---
+virt_domain_packages:
+  - libvirt
+  - libvirt-daemon
+  - python3-libvirt
+  - python3-lxml

--- a/tests/integration/targets/virt/vars/RedHat.yml
+++ b/tests/integration/targets/virt/vars/RedHat.yml
@@ -1,0 +1,9 @@
+---
+# RHEL 8/CentOS 8 only provides python-libvirt package for the default Python
+ansible_python_interpreter: /usr/libexec/platform-python
+
+virt_domain_packages:
+  - libvirt
+  - libvirt-daemon
+  - python3-libvirt
+  - python3-lxml

--- a/tests/integration/targets/virt/vars/Ubuntu-18.04.yml
+++ b/tests/integration/targets/virt/vars/Ubuntu-18.04.yml
@@ -1,0 +1,5 @@
+---
+virt_domain_packages:
+  - libvirt-daemon
+  - python-libvirt
+  - python-lxml

--- a/tests/integration/targets/virt/vars/Ubuntu-20.04.yml
+++ b/tests/integration/targets/virt/vars/Ubuntu-20.04.yml
@@ -1,0 +1,6 @@
+---
+virt_domain_packages:
+  - libvirt-daemon
+  - libvirt-daemon-system
+  - python-libvirt
+  - python-lxml

--- a/tests/integration/targets/virt/vars/Ubuntu.yml
+++ b/tests/integration/targets/virt/vars/Ubuntu.yml
@@ -1,0 +1,6 @@
+---
+virt_domain_packages:
+  - libvirt-daemon
+  - libvirt-daemon-system
+  - python3-libvirt
+  - python3-lxml

--- a/tests/integration/targets/virt/vars/default.yml
+++ b/tests/integration/targets/virt/vars/default.yml
@@ -1,0 +1,5 @@
+---
+virt_domain_packages:
+  - libvirt-daemon
+  - python-libvirt
+  - python-lxml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Implement --check support for the libvirt.virt module

Fixes #98.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
virt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Initial implementation to support --check mode.

This adds checking to the Virt class to make check mode calls no-ops but returning valid information where possible. For the get methods this doesn't affect behaviour, but for state changes and for defining domains this will make the Virt class do nothing in check mode.

For defining a new domain, this will pretty-print both XML definitions to make the diff output clean. It's not perfect because libvirt adds additional attributes when defining a domain that are implicit. Those will not change the domain if they are not specified in the input XML.

Tested check mode: define/undefine.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [libvirt-domain : Define Domain (domain)] ***********************************************************************************************************************************************************************************************************************************************
--- before
+++ after
@@ -1,37 +1,37 @@
-<domain type="kvm">
+<domain xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0" type="kvm">
   <name>domain</name>
   <uuid>snip</uuid>
-  <title>Windows 11</title>
-  <description>Windows 11 21H2</description>
+  <title>Windows 10</title>
+  <description>Windows 10 21H2</description>
   <metadata>
     <libosinfo:libosinfo xmlns:libosinfo="http://libosinfo.org/xmlns/libvirt/domain/1.0">
...snip
```
