### PR TITLE
Implement ansible module gathering UUID

### DIFF
--- a/changelogs/fragments/187-add-uuid.yaml
+++ b/changelogs/fragments/187-add-uuid.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - virt - implement the gathering of Dom UUIDs as per FR https://github.com/ansible-collections/community.libvirt/issues/187

--- a/plugins/doc_fragments/virt.py
+++ b/plugins/doc_fragments/virt.py
@@ -36,7 +36,7 @@ options:
   command:
     description:
       - In addition to state management, various non-idempotent commands are available.
-    choices: [ create, define, destroy, freemem, get_xml, info, list_vms, nodeinfo, pause, shutdown, start, status, stop, undefine, unpause, virttype ]
+    choices: [ create, define, destroy, freemem, get_xml, info, list_vms, nodeinfo, pause, shutdown, start, status, stop, undefine, unpause, uuid, virttype ]
     type: str
     """
 

--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -176,7 +176,7 @@ VIRT_SUCCESS = 0
 VIRT_UNAVAILABLE = 2
 
 ALL_COMMANDS = []
-VM_COMMANDS = ['create', 'define', 'destroy', 'get_xml', 'pause', 'shutdown', 'status', 'start', 'stop', 'undefine', 'unpause']
+VM_COMMANDS = ['create', 'define', 'destroy', 'get_xml', 'pause', 'shutdown', 'status', 'start', 'stop', 'undefine', 'unpause', 'uuid']
 HOST_COMMANDS = ['freemem', 'info', 'list_vms', 'nodeinfo', 'virttype']
 ALL_COMMANDS.extend(VM_COMMANDS)
 ALL_COMMANDS.extend(HOST_COMMANDS)
@@ -310,6 +310,10 @@ class LibvirtConnection(object):
 
     def define_from_xml(self, xml):
         return self.conn.defineXML(xml)
+
+    def get_uuid(self, vmid):
+        vm = self.conn.lookupByName(vmid)
+        return vm.UUIDString()
 
 
 class Virt(object):
@@ -481,6 +485,10 @@ class Virt(object):
         """
         self.__get_conn()
         return self.conn.define_from_xml(xml)
+
+    def get_uuid(self, vmid):
+        self.__get_conn()
+        return self.conn.get_uuid(vmid)
 
 
 # A dict of interface types (found in their `type` attribute) to the
@@ -766,6 +774,9 @@ def core(module):
                 res = getattr(v, command)(guest, flag)
                 if not isinstance(res, dict):
                     res = {command: res}
+
+            elif command == 'uuid':
+                res = {'uuid': v.get_uuid(guest)}
 
             else:
                 res = getattr(v, command)(guest)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This adds feature as per https://github.com/ansible-collections/community.libvirt/issues/187

TL;DR for some automations, the UUID of the domain is required. This PR adds the ability to get the domain via the ansible module
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
This is an addition to the plugin `virt.py` which allows the ansible module to make use of the `UUIDString()` already available in the underlying libvirt python module


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
A simply playbook will demonstrate the UUID:

```
---
- name: get UUID
  gather_facts: false
  hosts: localhost
  tasks:
  - name: register vm info
    community.libvirt.virt:
      command: uuid
      name: "my_domain"
    register: vminfo

  - name: display uuid
    debug:
      var: vminfo
```

Which will result in the following output

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ok: [localhost] => {
    "vminfo": {
        "changed": false,
        "failed": false,
        "uuid": "1462dd3b-48ed-4efe-99bc-4505dfd60463"
    }
}

```
