### PR TITLE
implement the removal of volumes when a domain is undefined

### DIFF
--- a/changelogs/fragments/177-undefine-disks.yaml
+++ b/changelogs/fragments/177-undefine-disks.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - virt - implement the removal of volumes for a dom as per FR https://github.com/ansible-collections/community.libvirt/issues/177

--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -18,7 +18,7 @@ description:
      - Manages virtual machines supported by I(libvirt).
 options:
     flags:
-        choices: [ 'managed_save', 'snapshots_metadata', 'nvram', 'keep_nvram', 'checkpoints_metadata', 
+        choices: [ 'managed_save', 'snapshots_metadata', 'nvram', 'keep_nvram', 'checkpoints_metadata',
                     'delete_volumes']
         description:
             - Pass additional parameters.

--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -18,8 +18,7 @@ description:
      - Manages virtual machines supported by I(libvirt).
 options:
     flags:
-        choices: [ 'managed_save', 'snapshots_metadata', 'nvram', 'keep_nvram', 'checkpoints_metadata',
-                    'delete_volumes']
+        choices: [ 'managed_save', 'snapshots_metadata', 'nvram', 'keep_nvram', 'checkpoints_metadata', 'delete_volumes']
         description:
             - Pass additional parameters.
             - Currently only implemented with command C(undefine).

--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -18,7 +18,8 @@ description:
      - Manages virtual machines supported by I(libvirt).
 options:
     flags:
-        choices: [ 'managed_save', 'snapshots_metadata', 'nvram', 'keep_nvram', 'checkpoints_metadata']
+        choices: [ 'managed_save', 'snapshots_metadata', 'nvram', 'keep_nvram', 'checkpoints_metadata', 
+                    'delete_volumes']
         description:
             - Pass additional parameters.
             - Currently only implemented with command C(undefine).
@@ -197,6 +198,7 @@ ENTRY_UNDEFINE_FLAGS_MAP = {
     'nvram': 4,
     'keep_nvram': 8,
     'checkpoints_metadata': 16,
+    'delete_volumes': 32,
 }
 
 MUTATE_FLAGS = ['ADD_UUID', 'ADD_MAC_ADDRESSES', 'ADD_MAC_ADDRESSES_FUZZY']
@@ -269,7 +271,10 @@ class LibvirtConnection(object):
         return self.find_vm(vmid).destroy()
 
     def undefine(self, vmid, flag):
-        return self.find_vm(vmid).undefineFlags(flag)
+        vm = self.find_vm(vmid)
+        if flag & 32:
+            self.delete_domain_volumes(vmid)
+        return vm.undefineFlags(flag)
 
     def get_status2(self, vm):
         state = vm.info()[0]
@@ -314,6 +319,16 @@ class LibvirtConnection(object):
     def get_uuid(self, vmid):
         vm = self.conn.lookupByName(vmid)
         return vm.UUIDString()
+
+    def delete_domain_volumes(self, vmid):
+        dom_xml = self.get_xml(vmid)
+        root = etree.fromstring(dom_xml)
+        disk_objects = root.findall(".//disk[@type='file']/source")
+        for disk in disk_objects:
+            disk_path = disk.get('file')
+            disk_volumes = self.conn.storageVolLookupByPath(disk_path)
+            if disk_volumes:
+                disk_volumes.delete()
 
 
 class Virt(object):
@@ -489,6 +504,10 @@ class Virt(object):
     def get_uuid(self, vmid):
         self.__get_conn()
         return self.conn.get_uuid(vmid)
+
+    def delete_domain_volumes(self, vmid):
+        self.__get_conn()
+        return self.conn.delete_domain_volumes(vmid)
 
 
 # A dict of interface types (found in their `type` attribute) to the
@@ -756,7 +775,7 @@ def core(module):
                 # Use the undefine function with flag to also handle various metadata.
                 # This is especially important for UEFI enabled guests with nvram.
                 # Provide flag as an integer of all desired bits, see 'ENTRY_UNDEFINE_FLAGS_MAP'.
-                # Integer 23 takes care of all cases (23 = 1 + 2 + 4 + 16).
+                # Integer 55 takes care of all cases (55 = 1 + 2 + 4 + 16 + 32).
                 flag = 0
                 if flags is not None:
                     if force is True:
@@ -769,7 +788,7 @@ def core(module):
                         # Get and add flag integer from mapping, otherwise 0.
                         flag += ENTRY_UNDEFINE_FLAGS_MAP.get(item, 0)
                 elif force is True:
-                    flag = 23
+                    flag = 55
                 # Finally, execute with flag
                 res = getattr(v, command)(guest, flag)
                 if not isinstance(res, dict):

--- a/tests/integration/targets/virt_undefine/defaults/main.yml
+++ b/tests/integration/targets/virt_undefine/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+vm_name: fedora-test
+vm_ram_mb: 256
+vm_vcpus: 1
+libvirt_disk_path: "/var/lib/libvirt/images"
+libvirt_disk_size: "1"
+libvirt_pool_name: "default"

--- a/tests/integration/targets/virt_undefine/files/Dockerfile_Fedora
+++ b/tests/integration/targets/virt_undefine/files/Dockerfile_Fedora
@@ -1,0 +1,36 @@
+FROM fedora:latest
+
+RUN dnf install @virtualization -y
+
+RUN dnf update -y && \
+    dnf install -y \
+        bridge-utils \
+        dmidecode \
+        dnsmasq \
+        ebtables \
+        iproute \
+        iptables \
+        edk2-ovmf \
+        qemu-kvm \
+        tini \
+        python3-pip \
+        python3-libvirt \
+        python3-lxml \
+        && \
+    dnf clean all
+
+RUN ln -s /usr/bin/qemu-system-x86_64 /usr/libexec/qemu-kvm
+
+RUN sed -i '/^#stdio_handler/ a\stdio_handler = "file"' /etc/libvirt/qemu.conf
+
+COPY config/pools/* /etc/libvirt/storage/
+COPY config/networks/* /etc/libvirt/qemu/networks/
+RUN mkdir -p /etc/libvirt/storage/autostart /etc/libvirt/qemu/networks/autostart && \
+    for pool in /etc/libvirt/storage/*.xml; do \
+        ln -sf "../${pool##*/}" /etc/libvirt/storage/autostart/; \
+    done && \
+    for net in /etc/libvirt/qemu/networks/*.xml; do \
+        ln -sf "../${net##*/}" /etc/libvirt/qemu/networks/autostart/; \
+    done
+
+CMD ["/usr/bin/tini", "/usr/sbin/libvirtd"]

--- a/tests/integration/targets/virt_undefine/files/Dockerfile_Ubuntu
+++ b/tests/integration/targets/virt_undefine/files/Dockerfile_Ubuntu
@@ -1,0 +1,37 @@
+FROM ubuntu:24.04
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get -y install \
+        bridge-utils \
+        dmidecode \
+        dnsmasq \
+        ebtables \
+        iproute2 \
+        iptables \
+        libvirt-clients \
+        libvirt-daemon-system \
+        ovmf \
+#        qemu-efi \
+        qemu-kvm \
+        tini \
+        && \
+    apt-get clean
+
+RUN apt install python3-pip python3-libvirt python3-lxml -y
+
+RUN ln -s /usr/bin/qemu-system-amd64 /usr/libexec/qemu-kvm
+
+RUN sed -i '/^#stdio_handler/ a\stdio_handler = "file"' /etc/libvirt/qemu.conf
+
+COPY config/pools/* /etc/libvirt/storage/
+COPY config/networks/* /etc/libvirt/qemu/networks/
+RUN mkdir -p /etc/libvirt/storage/autostart /etc/libvirt/qemu/networks/autostart && \
+    for pool in /etc/libvirt/storage/*.xml; do \
+        ln -sf "../${pool##*/}" /etc/libvirt/storage/autostart/; \
+    done && \
+    for net in /etc/libvirt/qemu/networks/*.xml; do \
+        ln -sf "../${net##*/}" /etc/libvirt/qemu/networks/autostart/; \
+    done
+
+CMD ["/usr/bin/tini", "/usr/sbin/libvirtd"]

--- a/tests/integration/targets/virt_undefine/files/vm_template.xml.j2
+++ b/tests/integration/targets/virt_undefine/files/vm_template.xml.j2
@@ -1,0 +1,50 @@
+<domain type='kvm'>
+  <name>{{ vm_name }}</name>
+  <memory unit='MiB'>{{ vm_ram_mb }}</memory>
+  <vcpu placement='static'>{{ vm_vcpus }}</vcpu>
+  <os>
+    <type arch='x86_64' machine='q35'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <cpu mode="host-passthrough" check="none" migratable="on"/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>destroy</on_crash>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <devices>
+    <emulator>/usr/libexec/qemu-kvm</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2'/>
+      <source file='{{ libvirt_disk_path }}/{{ vm_name }}.qcow2'/>
+      <target dev='vda' bus='virtio'/>
+      <address type='pci' domain='0x0000' bus='0x05' slot='0x00' function='0x0'/>
+    </disk>
+    <channel type="unix">
+      <target type="virtio" name="org.qemu.guest_agent.0"/>
+      <address type="virtio-serial" controller="0" bus="0" port="1"/>
+    </channel>
+    <input type='tablet' bus='usb'>
+      <address type='usb' bus='0' port='1'/>
+    </input>
+    <input type='mouse' bus='ps2'/>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type="vnc" port="-1" autoport="yes">
+      <listen type="address"/>
+    </graphics>
+    <video>
+      <model type="virtio" heads="1" primary="yes"/>
+      <address type="pci" domain="0x0000" bus="0x00" slot="0x01" function="0x0"/>
+    </video>
+    <memballoon model='virtio'>
+      <address type='pci' domain='0x0000' bus='0x06' slot='0x00' function='0x0'/>
+    </memballoon>
+    <rng model='virtio'>
+      <backend model='random'>/dev/urandom</backend>
+      <address type='pci' domain='0x0000' bus='0x07' slot='0x00' function='0x0'/>
+    </rng>
+  </devices>
+</domain>

--- a/tests/integration/targets/virt_undefine/tasks/main.yml
+++ b/tests/integration/targets/virt_undefine/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+- name: Create VM XML definition
+  template:
+    src: files/vm_template.xml.j2
+    dest: "/tmp/{{ vm_name }}.xml"
+
+- name: Define VM
+  community.libvirt.virt:
+    command: define
+    xml: "{{ lookup('file', '/tmp/' + vm_name + '.xml') }}"
+    uri: qemu:///system
+
+- name: Create the disk image file
+  ansible.builtin.command: "qemu-img create -f qcow2 {{ libvirt_disk_path }}/{{ vm_name }}.qcow2 {{ libvirt_disk_size }}G"
+
+- name: Validate the VM
+  community.libvirt.virt:
+    command: list_vms
+  register: vm_list
+
+- name: Show VMs
+  debug:
+    var: vm_list
+
+- name: Check if file exists
+  stat:
+    path: "{{ libvirt_disk_path }}/{{ vm_name }}.qcow2"
+  register: file_status
+
+- name: Assert file exists
+  assert:
+    that:
+      - file_status.stat.exists
+    fail_msg: "QCOW file does not exist"
+    success_msg: "File exists as expected"
+
+
+- name: Refresh the storage pool
+  community.libvirt.virt_pool:
+      command: refresh
+      name: "{{ libvirt_pool_name }}"
+
+- name: Destroy VMs
+  community.libvirt.virt:
+    state: destroyed
+    name: "{{ vm_name }}"
+
+- name: remove and undefine vm
+  community.libvirt.virt:
+    command: undefine
+    name: "{{ vm_name }}"
+    flags: managed_save,snapshots_metadata,delete_volumes
+
+- name: Check if file exists
+  stat:
+    path: "{{ libvirt_disk_path }}/{{ vm_name }}.qcow2"
+  register: file_status
+
+- name: Assert file does not exist
+  assert:
+    that:
+      - not file_status.stat.exists
+    success_msg: "QCOW file does not exist"
+    fail_msg: "File exists... failed to remove"

--- a/tests/integration/targets/virt_undefine/tasks/main.yml
+++ b/tests/integration/targets/virt_undefine/tasks/main.yml
@@ -10,8 +10,11 @@
     xml: "{{ lookup('file', '/tmp/' + vm_name + '.xml') }}"
     uri: qemu:///system
 
-- name: Create the disk image file
-  ansible.builtin.command: "qemu-img create -f qcow2 {{ libvirt_disk_path }}/{{ vm_name }}.qcow2 {{ libvirt_disk_size }}G"
+- name: Create the disk image file for base image
+  ansible.builtin.command: "qemu-img create -f qcow2 {{ libvirt_disk_path }}/{{ vm_name }}_copy.qcow2 {{ libvirt_disk_size }}G"
+
+- name: Copy the base image for another vm
+  ansible.builtin.command: "qemu-img create -f qcow2 -F qcow2 -b {{ libvirt_disk_path }}/{{ vm_name }}_copy.qcow2 {{ libvirt_disk_path }}/{{ vm_name }}.qcow2"
 
 - name: Validate the VM
   community.libvirt.virt:
@@ -62,3 +65,15 @@
       - not file_status.stat.exists
     success_msg: "QCOW file does not exist"
     fail_msg: "File exists... failed to remove"
+
+- name: Check if base image still exists
+  stat:
+    path: "{{ libvirt_disk_path }}/{{ vm_name }}_copy.qcow2"
+  register: base_image
+
+- name: Assert base image still exists
+  assert:
+    that:
+      - base_image.stat.exists
+    success_msg: "BASE QCOW file still exists"
+    fail_msg: "Base Image Missing."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When you undefine a domain currently the volumes are left behind as a manual cleanup task
Fixes #177 and #171 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
virt.py has been adjusted to handle a new `delete_volumes` flag

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
A new `delete_domain_volumes` function is created which does not return anything. It gets the disk objects from the xml by using `self.get_xml`. It then loops over these volumes and using the underlying python function `.delete()` to remove the disk.

The undefine function has been modified slightly to delete the disk if the flag `32` which is the `delete_volumes` flag is detected

```
    def undefine(self, vmid, flag):
        vm = self.find_vm(vmid)
        if flag & 32:
            self.delete_domain_volumes(vmid)
        return vm.undefineFlags(flag)
```

I'm unsure if this is the best approach, but give the layout of the current code base this made the most sense.

Sample playbook:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: remove vm
  hosts: localhost
  gather_facts: false
  vars:
    vm: "ocp-control3"
  tasks:
    - name: Destroy bootstrap VMs
      virt:
        state: destroyed
        name: "{{ vm }}"

    - name: remove and undefine vm
      community.libvirt.virt:
        command: undefine
        name: "{{ vm }}"
        flags: managed_save,snapshots_metadata,delete_volumes
```

And the output:

```
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "autostart": null,
            "command": "undefine",
            "flags": [
                "managed_save",
                "snapshots_metadata",
                "delete_volumes"
            ],
            "force": null,
            "mutate_flags": [
                "ADD_UUID"
            ],
            "name": "ocp-control3",
            "state": null,
            "uri": "qemu:///system",
            "xml": null
        }
    },
    "undefine": 0
}
```
