### PR TITLE
Add new virt_cloud_instance module for provisioning VMs from cloud images

### DIFF
--- a/plugins/doc_fragments/virt_install.py
+++ b/plugins/doc_fragments/virt_install.py
@@ -1,0 +1,1688 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    OPTIONS_MEMORY = """
+options:
+  memory:
+    type: int
+    description:
+      - Memory to allocate for the guest, in MiB.
+  memory_opts:
+    type: dict
+    description:
+      - Additional options for memory allocation.
+    suboptions:
+      current_memory:
+        type: int
+        description:
+          - The actual allocation of memory for the guest, in MiB.
+      max_memory:
+        type: int
+        description:
+          - The run time maximum memory allocation of the guest, in MiB.
+      max_memory_opts:
+        type: dict
+        description:
+          - Additional options for maximum memory configuration.
+        suboptions:
+          slots:
+            type: int
+            description:
+              - The number of slots available for adding memory to the guest.
+    """
+
+    OPTIONS_MEMORYBACKING = """
+options:
+  memorybacking:
+    type: dict
+    description:
+      - Specify how virtual memory pages are backed by host pages
+    suboptions:
+      hugepages:
+        type: bool
+        description:
+          - Use huge pages for memory backing.
+      hugepage_specs:
+        type: list
+        elements: dict
+        description:
+          - Configure hugepage specifications for memory backing.
+        suboptions:
+          page_size:
+            type: int
+            description:
+              - Specify the hugepage size with a unit suffix.
+          nodeset:
+            type: str
+            description:
+              - Specify the guest's NUMA nodes to certain hugepage sizes.
+      nosharepages:
+        type: bool
+        description:
+          - Instructs hypervisor to disable shared pages (memory merge, KSM) for this domain.
+      locked:
+        type: bool
+        description:
+          - Memory pages will be locked in host's memory and will not be swapped out.
+      access:
+        type: dict
+        description:
+          - Configure memory access permissions.
+        suboptions:
+          mode:
+            type: str
+            choices: [ shared, private ]
+            description:
+              - The access mode for the memory.
+      allocation:
+        type: dict
+        description:
+          - Configure memory allocation behavior.
+        suboptions:
+          mode:
+            type: str
+            choices: [ immediate, ondemand ]
+            description:
+              - Specify when to allocate the memory by supplying either V(immediate) or V(ondemand).
+          threads:
+            type: int
+            description:
+              - The number of threads that hypervisor uses to allocate memory.
+      discard:
+        type: bool
+        description:
+          - If set to V(true), the memory content is discarded just before guest shuts down (or when DIMM module is unplugged).
+    """
+
+    OPTIONS_ARCH = """
+options:
+  arch:
+    type: str
+    description:
+      - Request a non-native CPU architecture for the guest virtual machine.
+      - If omitted, the host CPU architecture will be used in the guest.
+    """
+
+    OPTIONS_MACHINE = """
+options:
+  machine:
+    type: str
+    description:
+      - The machine type to emulate. This will typically not need to be specified for Xen or KVM.
+    """
+
+    OPTIONS_METADATA = """
+options:
+  metadata:
+    type: dict
+    description:
+      - Specify the metadata for the guest virtual machine.
+      - The dictionary contains key/value pairs that define individual metadata entries.
+      - 'e.g. V({uuid: 4dea22b3-1d52-d8f3-2516-782e98ab3fa0})'
+      - Use C(virt-install --metadata=?) to see a list of all available sub options.
+    """
+
+    OPTIONS_EVENTS = """
+options:
+  events:
+    type: dict
+    description:
+      - Specify events values for the guest.
+    suboptions:
+      on_poweroff:
+        type: str
+        choices: [ destroy, restart, preserve, rename-restart ]
+        description:
+          - Action to take when the guest requests a poweroff.
+      on_reboot:
+        type: str
+        choices: [ destroy, restart, preserve, rename-restart ]
+        description:
+          - Action to take when the guest requests a reboot.
+      on_crash:
+        type: str
+        choices: [ destroy, restart, preserve, rename-restart, coredump-destroy, coredump-restart ]
+        description:
+          - Action to take when the guest crashes.
+      on_lockfailure:
+        type: str
+        choices: [ poweroff, restart, pause, ignore ]
+        description:
+          - Action to take when when a lock manager loses resource locks.
+    """
+
+    OPTIONS_RESOURCE = """
+options:
+  resource:
+    type: dict
+    description:
+      - Specify resource partitioning for the guest.
+      - The dictionary contains key/value pairs that define individual resource entries.
+      - Use C(virt-install --resource=?) to see a list of all available sub options.
+    """
+
+    OPTIONS_SYSINFO = """
+options:
+  sysinfo:
+    type: dict
+    description:
+      - Configure sysinfo/SMBIOS values exposed to the VM OS.
+      - The dictionary contains key/value pairs that define individual sysinfo entries.
+      - Use C(virt-install --sysinfo=?) to see a list of all available sub options.
+    """
+
+    OPTIONS_QEMU_COMMANDLINE = """
+options:
+  qemu_commandline:
+    type: str
+    description:
+      - Pass options directly to the qemu emulator. Only works for the libvirt qemu driver.
+    """
+
+    OPTIONS_VCPUS = """
+options:
+  vcpus:
+    type: int
+    description:
+      - Number of virtual cpus to configure for the guest.
+  vcpus_opts:
+    type: dict
+    description:
+      - Additional options for virtual CPU configuration.
+    suboptions:
+      maxvcpus:
+        type: int
+        description:
+          - If specified, the guest will be able to hotplug up to MAX vcpus while the guest is running.
+      sockets:
+        type: int
+        description:
+          - Total number of CPU sockets
+      dies:
+        type: int
+        description:
+          - Number of dies per socket
+      clusters:
+        type: int
+        description:
+          - number of clusters per die
+      cores:
+        type: int
+        description:
+          - Number of cores per cluster
+      threads:
+        type: int
+        description:
+          - Number of threads per core
+      current:
+        type: int
+        description:
+          - Specify whether fewer than the maximum number of virtual CPUs should be enabled.
+      cpuset:
+        type: str
+        description:
+          - A comma-separated list of physical CPU numbers that domain process and virtual CPUs can be pinned to by default.
+      placement:
+        type: str
+        choices: [ static, auto ]
+        description:
+          - Indicate the CPU placement mode for domain process
+      vcpu_specs:
+        type: list
+        elements: dict
+        description:
+          - Configure individual vCPU properties.
+          - Each dictionary entry contains a property name and its corresponding value.
+    """
+
+    OPTIONS_NUMATUNE = """
+options:
+  numatune:
+    type: dict
+    description:
+      - Tune NUMA policy for the domain process.
+    suboptions:
+      memory:
+        type: dict
+        description:
+          - Specifies how to allocate memory for the domain process on a NUMA host.
+        suboptions:
+          mode:
+            type: str
+            choices: [ interleave, preferred, strict ]
+            description:
+              - Can be one of V(interleave), V(preferred), or V(strict) (the default)
+          nodeset:
+            type: str
+            description:
+              - Specifies the NUMA nodes to allocate memory from.
+          placement:
+            type: str
+            choices: [ static, auto ]
+            description:
+              - Indicate the memory placement mode for domain process.
+      memnode_specs:
+        type: list
+        elements: dict
+        description:
+          - Specify memory allocation policies per each guest NUMA node.
+        suboptions:
+          cellid:
+            type: int
+            description:
+              - Specify the NUMA node ID.
+          mode:
+            type: str
+            choices: [ interleave, preferred, strict ]
+            description:
+              - Can be one of V(interleave), V(preferred), or V(strict) (the default)
+          nodeset:
+            type: str
+            description:
+              - Specifies the NUMA nodes to allocate memory from.
+    """
+
+    OPTIONS_MEMTUNE = """
+options:
+  memtune:
+    type: dict
+    description:
+      - Tune memory policy for the domain process.
+      - The dictionary contains key/value pairs that define individual memtune entries.
+    """
+
+    OPTIONS_BLKIOTUNE = """
+options:
+  blkiotune:
+    type: dict
+    description:
+      - Tune block I/O policy for the domain process.
+    suboptions:
+      weight:
+        type: int
+        description:
+          - The overall I/O weight of the guest.
+          - The value should be in the range [100, 1000]. After kernel 2.6.39, the value could be in the range [10, 1000].
+      devices:
+        type: list
+        elements: dict
+        description:
+          - Tune the weights for individual host block device used by the guest.
+          - Each dictionary entry contains a property name and its corresponding value.
+    """
+
+    OPTIONS_CPU = """
+options:
+  cpu:
+    type: dict
+    description:
+      - Configure the CPU model and CPU features exposed to the guest.
+    suboptions:
+      model:
+        type: str
+        description:
+          - A valid CPU model or configuration mode for the guest.
+          - "The possible values include: V(host-model), V(host-passthrough) and V(maximum)."
+      model_opts:
+        type: dict
+        description:
+          - Additional options for CPU model configuration.
+        suboptions:
+          fallback:
+            type: str
+            choices: [ forbid, allow ]
+            description:
+              - Specify whether to automatically fall back to the closest model supported by the hypervisor if unable to use the exact CPU model.
+          vendor_id:
+            type: str
+            description:
+              - Set the vendor id seen by the guest. It must be exactly 12 characters long.
+              - Typical possible values are I(AuthenticAMD) and I(GenuineIntel).
+      match:
+        type: str
+        choices: [ exact, minimum, strict ]
+        description:
+          - Specify how strictly the CPU model should be matched.
+      migratable:
+        type: bool
+        description:
+          - Specify whether this CPU model is migratable.
+      vendor:
+        type: str
+        description:
+          - Specify CPU vendor requested by the guest
+          - The list of supported vendors can be found in I(cpu_map/*_vendors.xml).
+      features:
+        type: dict
+        description:
+          - Fine-tune features provided by the selected CPU model.
+          - The value should be a dictionary where each key is a feature name and the value is a dictionary of options for that feature.
+          - An empty object V({}) for a feature indicates to enable that feature.
+        suboptions:
+          policy:
+            type: str
+            choices: [ force, require, optional, disable, forbid ]
+            description:
+              - The policy for the CPU feature.
+              - If set to V(force), the vCPU will claim the feature is supported regardless of it being supported by host CPU.
+              - If set to V(require), guest creation will fail unless the feature is supported by the host CPU or the hypervisor is able to emulate it.
+              - If set to V(optional), the feature will be supported by vCPU if and only if it is supported by host CPU.
+              - If set to V(disable), the feature will not be supported by virtual CPU.
+              - If set to V(forbid), guest creation will fail if the feature is supported by host CPU.
+      cache:
+        type: dict
+        description:
+          - vCPU cache configuration for the guest.
+        suboptions:
+          mode:
+            type: str
+            choices: [ emulate, passthrough, disable ]
+            description:
+              - If set to V(emulate), the hypervisor will provide a fake CPU cache data.
+              - If set to V(passthrough), the host CPU cache data reported by the host CPU will be passed through to the vCPU.
+              - If set to V(disable), the vCPU will report no CPU cache at all.
+          level:
+            type: int
+            description:
+              - Specify the level of CPU cache.
+      numa:
+        type: dict
+        description:
+          - Configure NUMA topology for the guest.
+        suboptions:
+          cell_specs:
+            type: list
+            elements: dict
+            description:
+              - Specify a NUMA cell configuration.
+            suboptions:
+              id:
+                type: int
+                description:
+                  - Specify the NUMA node ID.
+              cpus:
+                type: str
+                description:
+                  - Specify the CPU or range of CPUs that are part of this node.
+              memory:
+                type: int
+                description:
+                  - Specify the node memory size with a unit suffix.
+              mem_access:
+                type: str
+                choices: [ shared, private ]
+                description:
+                  - Specify the memory access mode for the NUMA node.
+                  - This is valid only for hugepages-backed memory and nvdimm modules.
+              discard:
+                type: bool
+                description:
+                  - Fine tune the discard feature for given NUMA node.
+              distances:
+                type: dict
+                description:
+                  - Define the distance between NUMA cells.
+                suboptions:
+                  sibling_specs:
+                    type: list
+                    elements: dict
+                    description:
+                      - Specify the distance value between sibling NUMA cells.
+                      - Each dictionary entry contains a property name and its corresponding value.
+              cache_specs:
+                type: list
+                elements: dict
+                description:
+                  - Describe memory side cache for memory proximity domains.
+                  - Each dictionary entry contains a property name and its corresponding value.
+          interconnects:
+            type: list
+            elements: dict
+            description:
+              - Describes the normalized memory read/write latency and bandwidth between Initiator Proximity Domains and Target Proximity Domains.
+            suboptions:
+              bandwidth_specs:
+                type: list
+                elements: dict
+                description:
+                  - Describe bandwidth between two memory nodes.
+                  - Each dictionary entry contains a property name and its corresponding value.
+              latency_specs:
+                type: list
+                elements: dict
+                description:
+                  - Describe latency between two memory nodes.
+                  - Each dictionary entry contains a property name and its corresponding value.
+    """
+
+    OPTIONS_CPUTUNE = """
+options:
+  cputune:
+    type: dict
+    description:
+      - Tune CPU parameters for the guest.
+    suboptions:
+      vcpupin_specs:
+        type: list
+        elements: dict
+        description:
+          - Specify which of host's physical CPUs the domain vCPU will be pinned to
+        suboptions:
+          vcpu:
+            type: int
+            description:
+              - Specify the vCPU ID.
+          cpuset:
+            type: str
+            description:
+              - A comma-separated list of physical CPU numbers.
+      emulatorpin:
+        type: dict
+        description:
+          - Specify which host CPUs the domain emulator will be pinned to.
+        suboptions:
+          cpuset:
+            type: str
+            description:
+              - Specify which physical CPUs to pin to.
+      iothreadpin_specs:
+        type: list
+        elements: dict
+        description:
+          - Specify which of host physical CPUs the IOThreads will be pinned to.
+        suboptions:
+          iothread:
+            type: int
+            description:
+              - Specify the IOThread ID.
+          cpuset:
+            type: str
+            description:
+              - Specify which physical CPUs to pin to.
+      vcpusched_specs:
+        type: list
+        elements: dict
+        description:
+          - Specify the scheduler type for particular vCPUs.
+        suboptions:
+          vcpus:
+            type: str
+            description:
+              - Select which vCPUs this setting applies to.
+          scheduler:
+            type: str
+            choices: [ batch, idle, fifo, rr ]
+            description:
+              - The scheduler type.
+          priority:
+            type: int
+            description:
+              - For real-time schedulers (fifo, rr), priority must be specified as well (and is ignored for non-real-time ones).
+              - The value range for the priority depends on the host kernel (usually 1-99).
+      iothreadsched_specs:
+        type: list
+        elements: dict
+        description:
+          - Specify the scheduler type for particular IOThreads.
+        suboptions:
+          iothreads:
+            type: str
+            description:
+              - Select which IOThreads this setting applies to.
+          scheduler:
+            type: str
+            choices: [ batch, idle, fifo, rr ]
+            description:
+              - The scheduler type.
+          priority:
+            type: int
+            description:
+              - For real-time schedulers (fifo, rr), priority must be specified as well (and is ignored for non-real-time ones).
+              - The value range for the priority depends on the host kernel (usually 1-99).
+      emulatorsched:
+        type: dict
+        description:
+          - Specify the scheduler type for emulator thread.
+        suboptions:
+          scheduler:
+            type: str
+            choices: [ batch, idle, fifo, rr ]
+            description:
+              - The scheduler type.
+          priority:
+            type: int
+            description:
+              - For real-time schedulers (fifo, rr), priority must be specified as well (and is ignored for non-real-time ones).
+              - The value range for the priority depends on the host kernel (usually 1-99).
+      shares:
+        type: int
+        description:
+          - Specify the proportional weighted share for the domain.
+      period:
+        type: int
+        description:
+          - "Specify the enforcement interval (unit: microseconds)."
+          - The value should be in range [1000, 1000000]. A period with value 0 means no value.
+      quota:
+        type: int
+        description:
+          - "Specify the maximum allowed bandwidth (unit: microseconds)."
+          - A domain with quota as any negative value indicates that the domain has infinite bandwidth for vCPU threads.
+      global_period:
+        type: int
+        description:
+          - "Specify the enforcement CFS scheduler interval (unit: microseconds) for the whole domain."
+      global_quota:
+        type: int
+        description:
+          - "Specify the maximum allowed bandwidth (unit: microseconds) within a period for the whole domain."
+      emulator_period:
+        type: int
+        description:
+          - "Specify the enforcement interval (unit: microseconds) for domain's emulator threads."
+      emulator_quota:
+        type: int
+        description:
+          - "Specify the maximum allowed bandwidth (unit: microseconds) for domain's emulator threads."
+      iothread_period:
+        type: int
+        description:
+          - "Specify the enforcement interval (unit: microseconds) for domain's IOThreads."
+      iothread_quota:
+        type: int
+        description:
+          - "Specify the maximum allowed bandwidth (unit: microseconds) for domain's IOThreads."
+    """
+
+    OPTIONS_SECURITY = """
+options:
+  security:
+    type: dict
+    description:
+      - Configure domain seclabel domain settings.
+      - The dictionary contains key/value pairs that define individual security entries.
+    """
+
+    OPTIONS_KEYWRAP = """
+options:
+  keywrap:
+    type: dict
+    description:
+      - Configure domain keywrap settings used for S390 cryptographic key management operations.
+    suboptions:
+      ciphers:
+        type: list
+        elements: dict
+        description:
+          - Specify the cipher settings for the domain.
+          - Each dictionary entry contains a property name and its corresponding value.
+    """
+    OPTIONS_IOTHREADS = """
+options:
+  iothreads:
+    type: int
+    description:
+      - Number of I/O threads to configure for the guest.
+  iothreads_opts:
+    type: dict
+    description:
+      - Additional options for I/O threads configuration.
+    suboptions:
+      iothread_specs:
+        type: list
+        elements: dict
+        description:
+          - Provide the capability to specifically define the IOThread ID's for the domain.
+        suboptions:
+          id:
+            type: int
+            description:
+              - Define the IOThread ID.
+          thread_pool_min:
+            type: int
+            description:
+              - Set lower boundary for number of worker threads for given IOThread.
+          thread_pool_max:
+            type: int
+            description:
+              - Set upper boundary for number of worker threads for given IOThread.
+      defaultiothread:
+        type: dict
+        description:
+          - Provide the capability to define the default event loop within hypervisor.
+        suboptions:
+          thread_pool_min:
+            type: int
+            description:
+              - Set lower boundary for number of worker threads for given IOThread.
+          thread_pool_max:
+            type: int
+            description:
+              - Set upper boundary for number of worker threads for given IOThread.
+    """
+
+    OPTIONS_FEATURES = """
+options:
+  features:
+    type: dict
+    description:
+      - Enable or disable certain machine features.
+      - The value should be a dictionary where each key is a feature name and the value is a dictionary of options for that feature.
+      - An empty object V({}) for a feature indicates to turn on that feature with default options.
+      - 'Example: V(hyperv.spinlocks: {state: off}), V(pvspinlock: {})'
+    """
+
+    OPTIONS_CLOCK = """
+options:
+  clock:
+    type: dict
+    description:
+      - Configure the clock for the guest.
+    suboptions:
+      offset:
+        type: str
+        description:
+          - Set the clock offset, e.g. V(utc) or V(localtime).
+      timers:
+        type: list
+        elements: dict
+        description:
+          - Tweak the guest's timer settings on the specific hypervisor.
+          - Each dictionary entry contains a property name and its corresponding value.
+    """
+
+    OPTIONS_PM = """
+options:
+  pm:
+    type: dict
+    description:
+      - Configure the power management for the guest.
+    suboptions:
+      suspend_to_mem:
+        type: dict
+        description:
+          - Configure BIOS support for S3 (suspend-to-mem) ACPI sleep states.
+        suboptions:
+          enabled:
+            type: bool
+            description:
+              - Enable or disable this sleep state.
+      suspend_to_disk:
+        type: dict
+        description:
+          - Configure BIOS support for S4 (suspend-to-disk) ACPI sleep states.
+        suboptions:
+          enabled:
+            type: bool
+            description:
+              - Enable or disable this sleep state.
+    """
+
+    OPTIONS_LAUNCH_SECURITY = """
+options:
+  launch_security:
+    type: dict
+    description:
+      - Enable launch security for the guest.
+    suboptions:
+      type:
+        type: str
+        description:
+          - The type of launch security to enable, e.g. V(sev).
+        required: true
+      policy:
+        type: str
+        description:
+          - The guest policy which must be maintained by the SEV firmware, e.g. V(0x01).
+      cbitpos:
+        type: int
+        description:
+          - The C-bit (aka encryption bit) location in guest page table entry.
+      reduced_phys_bits:
+        type: int
+        description:
+          - The physical address bit reduction, e.g. V(1).
+      dh_cert:
+        type: str
+        description:
+          - The guest owners base64 encoded Diffie-Hellman (DH) key.
+      session:
+        type: str
+        description:
+          - The guest owners base64 encoded session blob defined in the SEV API spec.
+    """
+
+    OPTIONS_CDROM = """
+options:
+  cdrom:
+    type: str
+    description:
+      - ISO file or CDROM device to use for VM install media.
+    """
+
+    OPTIONS_LOCATION = """
+options:
+  location:
+    type: str
+    description:
+      - The installation source, which can be a URL or a directory path containing the OS distribution installation media.
+  location_opts:
+    type: dict
+    description:
+      - Additional options for the installation source.
+    suboptions:
+      kernel:
+        type: str
+        description:
+          - The kernel path relative to the specified location.
+      initrd:
+        type: str
+        description:
+          - The initrd path relative to the specified location.
+    """
+
+    OPTIONS_PXE = """
+options:
+  pxe:
+    type: bool
+    description:
+      - Install the guest from PXE.
+    """
+
+    OPTIONS_IMPORT = """
+options:
+  import:
+    type: bool
+    description:
+      - Skip the OS installation process, and build a guest around an existing disk image.
+    """
+
+    OPTIONS_EXTRA_ARGS = """
+options:
+  extra_args:
+    type: str
+    description:
+      - Additional kernel command line arguments to pass to the installer when performing a guest install with O(location).
+    """
+
+    OPTIONS_INITRD_INJECT = """
+options:
+  initrd_inject:
+    type: str
+    description:
+      - Add PATH to the root of the initrd fetched with O(location).
+    """
+
+    OPTIONS_INSTALL = """
+options:
+  install:
+    type: dict
+    description:
+      - Additional options for the installation.
+      - This option is strictly for VM install operations, essentially configuring the first boot.
+    suboptions:
+      os:
+        type: str
+        description:
+          - The OS name from I(libosinfo), e.g. V(fedora29).
+        required: true
+      kernel:
+        type: str
+        description:
+          - Specify a kernel and initrd pair to use as install media.
+      initrd:
+        type: str
+        description:
+          - Specify a kernel and initrd pair to use as install media.
+      kernel_args:
+        type: str
+        description:
+          - Specify the installation-time kernel arguments.
+      kernel_args_overwrite:
+        type: bool
+        description:
+          - Override the virt-install default kernel arguments rather than appending to them.
+      bootdev:
+        type: str
+        description:
+          - Specify the install bootdev to boot for the install phase.
+      no_install:
+        type: bool
+        description:
+          - Tell virt-install that there isn't actually any install happening, and you just want to create the VM.
+    """
+
+    OPTIONS_UNATTENDED = """
+options:
+  unattended:
+    type: dict
+    description:
+      - Perform an unattended install using libosinfo's install script support.
+    suboptions:
+      profile:
+        type: str
+        description:
+          - Choose which I(libosinfo) unattended profile to use.
+      admin_password_file:
+        type: str
+        description:
+          - A file used to set the VM OS admin/root password from.
+      user_login:
+        type: str
+        description:
+          - The user login name to be used in the VM.
+      user_password_file:
+        type: str
+        description:
+          - A file used to set the VM user password.
+      product_key:
+        type: str
+        description:
+          - Set a Windows product key.
+    """
+
+    OPTIONS_CLOUD_INIT = """
+options:
+  cloud_init:
+    type: dict
+    description:
+      - Pass cloud-init metadata to the VM.
+      - A cloud-init NoCloud ISO file is generated, and attached to the VM as a CDROM device.
+    suboptions:
+      root_password_generate:
+        type: bool
+        description:
+          - Generate a new root password for the VM.
+      disable:
+        type: bool
+        description:
+          - Disable cloud-init in the VM for subsequent boots.
+          - Without this, cloud-init may reset auth on each boot.
+      root_password_file:
+        type: str
+        description:
+          - A file used to set the VM root password from.
+      root_ssh_key:
+        type: str
+        description:
+          - Specify a public key file to inject into the guest.
+      clouduser_ssh_key:
+        type: str
+        description:
+          - Specify a public key file to inject into the guest, providing ssh access to the default cloud-init user account.
+      network_config:
+        type: str
+        description:
+          - Specify a cloud-init network-config file content.
+      meta_data:
+        type: dict
+        description:
+          - Specify a cloud-init meta-data file content.
+      user_data:
+        type: str
+        description:
+          - Specify a cloud-init user-data file content.
+          - Can be provided as a YAML string (e.g., using the '|' operator in Ansible).
+    """
+
+    OPTIONS_BOOT = """
+options:
+  boot:
+    type: str
+    description:
+      - Set the boot device priority for post-install configuration.
+  boot_opts:
+    type: dict
+    description:
+      - Additional options for boot configuration.
+      - The dictionary contains key/value pairs that define individual boot options.
+    """
+
+    OPTIONS_IDMAP = """
+options:
+  idmap:
+    type: dict
+    description:
+      - Configure the UID or GID mapping for the guest.
+    suboptions:
+      uid:
+        type: dict
+        description:
+          - The UID mapping configuration.
+        suboptions:
+          start:
+            type: int
+            description:
+              - First user ID in container.
+          target:
+            type: int
+            description:
+              - The first user ID in container will be mapped to this target user ID in host.
+          count:
+            type: int
+            description:
+              - How many users in container are allowed to map to host's user.
+      gid:
+        type: dict
+        description:
+          - The GID mapping configuration.
+        suboptions:
+          start:
+            type: int
+            description:
+              - First group ID in container.
+          target:
+            type: int
+            description:
+              - The first group ID in container will be mapped to this target user ID in host.
+          count:
+            type: int
+            description:
+              - How many groups in container are allowed to map to host's user.
+    """
+
+    OPTIONS_OSINFO = """
+options:
+  osinfo:
+    type: dict
+    description:
+      - Optimize the guest configuration for a specific operating system.
+    suboptions:
+      name:
+        type: str
+        aliases: [ short_id ]
+        description:
+          - The OS name from libosinfo. (e.g. V(fedora32), V(win10))
+      id:
+        type: str
+        description:
+          - The full URL style libosinfo ID.
+      detect:
+        type: bool
+        description:
+          - Whether C(virt-install) should attempt OS detection from the specified install media.
+      require:
+        type: bool
+        description:
+          - Whether C(virt-install) should fail if OS detection fails.
+    """
+
+    OPTIONS_DISKS = """
+options:
+  disks:
+    type: list
+    elements: dict
+    description:
+      - Specify the storage devices for the guest.
+    suboptions:
+      path:
+        type: str
+        description:
+          - The path to some storage media to use, existing or not.
+      pool:
+        type: str
+        description:
+          - An existing libvirt storage pool name to create new storage on.
+      vol:
+        type: str
+        description:
+          - An existing libvirt storage volume to use.
+      size:
+        type: int
+        description:
+          - The size (in GiB) to use if creating new storage.
+      sparse:
+        type: bool
+        description:
+          - Whether to skip fully allocating newly created storage.
+      format:
+        type: str
+        description:
+          - Disk image format. For file volumes, this can be V(raw), V(qcow2), V(vmdk), etc.
+      backing_store:
+        type: str
+        description:
+          - Path to a disk to use as the backing store for the newly created image.
+      backing_format:
+        type: str
+        description:
+          - Disk image format of I(backing_store).
+      bus:
+        type: str
+        description:
+          - Disk bus type. (e.g. V(ide), V(sata), V(scsi), V(usb), V(virtio), V(xen))
+      readonly:
+        type: bool
+        description:
+          - Set drive as readonly
+      shareable:
+        type: bool
+        description:
+          - Set drive as shareable
+      cache:
+        type: str
+        choices: [ none, writethrough, directsync, unsafe, writeback ]
+        description:
+          - The cache mode to be used.
+      serial:
+        type: str
+        description:
+          - Serial number of the emulated disk device.
+      snapshot:
+        type: str
+        choices: [ "internal", "external", "no" ]
+        description:
+          - Indicates the default behavior of the disk during disk snapshots.
+      rawio:
+        type: bool
+        description:
+          - Specify whether the disk needs rawio capability.
+      sgio:
+        type: str
+        choices: [ filtered, unfiltered ]
+        description:
+          - Specify whether unprivileged SG_IO commands are filtered for the disk.
+          - Only available when the device is 'lun'.
+      transient:
+        type: bool
+        description:
+          - If V(true), this indicates that changes to the device contents should be reverted automatically when the guest exits.
+      transient_opts:
+        type: dict
+        description:
+          - Additional options for transient disk configuration.
+        suboptions:
+          share_backing:
+            type: bool
+            description:
+              - If V(true), the transient disk is supposed to be shared between multiple concurrently running VMs.
+      driver:
+        type: dict
+        description:
+          - Specify the details of the hypervisor disk driver.
+          - The dictionary contains key/value pairs that define individual properties.
+      source:
+        type: dict
+        description:
+          - Specify the details of the disk source.
+          - The dictionary contains key/value pairs that define individual properties.
+      target:
+        type: dict
+        description:
+          - Specify the details of the target disk device.
+          - The dictionary contains key/value pairs that define individual properties.
+      address:
+        type: dict
+        description:
+          - Specify the controller properties where the disk should be attached.
+          - The dictionary contains key/value pairs that define individual properties.
+      boot:
+        type: dict
+        description:
+          - Specify the boot order for the disk device.
+          - The dictionary contains key/value pairs that define individual properties.
+          - The per-device boot elements cannot be used together with general boot elements in the OS bootloader section.
+      iotune:
+        type: dict
+        description:
+          - Specify additional per-device I/O tuning.
+          - The dictionary contains key/value pairs that define individual properties.
+      blockio:
+        type: dict
+        description:
+          - Override the default block device properties for the disk.
+          - The dictionary contains key/value pairs that define individual properties.
+      geometry:
+        type: dict
+        description:
+          - Override geometry settings for the disk.
+          - The dictionary contains key/value pairs that define individual properties.
+    """
+
+    OPTIONS_FILESYSTEMS = """
+options:
+  filesystems:
+    type: list
+    elements: dict
+    description:
+      - Specifies directories on the host to export to the guest.
+    suboptions:
+      type:
+        type: str
+        choices: [ mount, template, file, block, ram, bind ]
+        description:
+          - Specify the source type of the filesystem.
+      accessmode:
+        type: str
+        choices: [ passthrough, mapped, squash ]
+        description:
+          - Specify the security mode for accessing the source.
+      source:
+        type: dict
+        description:
+          - The source directory configuration on the host.
+          - The dictionary contains key/value pairs that define individual properties.
+      target:
+        type: dict
+        description:
+          - The mount target configuration in the guest.
+          - The dictionary contains key/value pairs that define individual properties.
+      fmode:
+        type: str
+        description:
+          - The creation mode for files when used with the V(mapped) value for I(accessmode).
+      dmode:
+        type: str
+        description:
+          - The creation mode for directories when used with the V(mapped) value for I(accessmode).
+      multidevs:
+        type: str
+        choices: [ default, remap, forbid, warn ]
+        description:
+          - Specify how to deal with a filesystem export containing more than one device.
+      readonly:
+        type: bool
+        description:
+          - Enable exporting filesystem as a readonly mount for guest.
+      space_hard_limit:
+        type: int
+        description:
+          - Maximum space available to this guest's filesystem
+      space_soft_limit:
+        type: int
+        description:
+          - Maximum space available to this guest's filesystem.
+      driver:
+        type: dict
+        description:
+          - Specify the details of the hypervisor driver.
+          - The dictionary contains key/value pairs that define individual properties.
+      address:
+        type: dict
+        description:
+          - Specify the controller properties where the filesystem should be attached.
+          - The dictionary contains key/value pairs that define individual properties.
+      binary:
+        type: dict
+        description:
+          - Tune the options for virtiofsd.
+          - The dictionary contains key/value pairs that define individual properties.
+    """
+
+    OPTIONS_NETWORKS = """
+options:
+  networks:
+    type: list
+    elements: dict
+    description:
+      - Connect the guest to the host network.
+      - Empty list V([]) means no default network interface.
+    suboptions:
+      type:
+        type: str
+        choices: [ direct ]
+        description:
+          - The type of network interface.
+          - V(direct) provides direct attachment to host network interface using macvtap.
+          - If omitted, the type of network interface is determined by other options.
+      network:
+        type: str
+        description:
+          - Name of the libvirt virtual network to connect to.
+      bridge:
+        type: str
+        description:
+          - Name of the host bridge device to connect to.
+      hostdev:
+        type: str
+        description:
+          - Name of the host device to connect to for type=hostdev.
+          - This uses PCI passthrough to directly assign a network device.
+      mac:
+        type: dict
+        description:
+          - MAC address configuration for the network interface.
+        suboptions:
+          address:
+            type: str
+            description:
+              - Fixed MAC address for the guest interface.
+              - If not specified, a suitable address will be randomly generated.
+      mtu:
+        type: dict
+        description:
+          - Configure MTU settings for the virtual network link.
+           - The dictionary contains key/value pairs that define individual properties.
+      state:
+        type: dict
+        description:
+          - Set state of the virtual network link
+          - The dictionary contains key/value pairs that define individual properties.
+      model:
+        type: dict
+        description:
+          - Network device model configuration.
+        suboptions:
+          type:
+            type: str
+            description:
+              - Network device model as seen by the guest.
+              - Examples include V(virtio), V(e1000), V(rtl8139).
+      driver:
+        type: dict
+        description:
+          - Specify the details of the hypervisor driver.
+          - The dictionary contains key/value pairs that define individual properties.
+      boot:
+        type: dict
+        description:
+          - Specify the boot order for the network interface.
+          - The dictionary contains key/value pairs that define individual properties.
+          - The per-device boot elements cannot be used together with general boot elements in the OS bootloader section.
+      filterref:
+        type: dict
+        description:
+          - Configure network traffic filter rules for the guest.
+          - The dictionary contains key/value pairs that define individual properties.
+      rom:
+        type: dict
+        description:
+          - Specify the interface ROM BIOS configuration
+          - The dictionary contains key/value pairs that define individual properties.
+      source:
+        type: dict
+        description:
+          - Specify the details of the source network interface.
+          - The dictionary contains key/value pairs that define individual properties.
+      target:
+        type: dict
+        description:
+          - Specify the details of the target network device.
+          - The dictionary contains key/value pairs that define individual properties.
+      address:
+        type: dict
+        description:
+          - Specify the controller properties where the filesystem should be attached.
+          - The dictionary contains key/value pairs that define individual properties.
+      virtualport:
+        type: dict
+        description:
+          - Configure virtual port settings for the network interface.
+          - The dictionary contains key/value pairs that define individual properties.
+          - Common properties include I(type) (e.g. V(802.1Qbg), V(802.1Qbh), V(openvswitch), V(midonet)) and C(parameters) containing type-specific settings.
+      trust_guest_rx_filters:
+        type: bool
+        description:
+          - When set to V(true), enables the host to trust and accept MAC address changes and receive filter modifications reported by the guest VM.
+    """
+
+    OPTIONS_GRAPHICS_DEVICES = """
+options:
+  graphics:
+    type: dict
+    description:
+      - Configure the graphical display for the guest virtual machine.
+      - The dictionary contains key/value pairs that define individual properties.
+      - Common properties include I(type) (e.g. V(vnc), V(spice)) and I(listen).
+  graphics_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple graphics devices for the guest.
+    """
+
+    OPTIONS_VIRT_TYPE = """
+options:
+  virt_type:
+    type: str
+    description:
+      - The hypervisor used to create the VM guest. Example choices are V(kvm), V(qemu), or V(xen).
+    """
+
+    OPTIONS_HVM = """
+options:
+  hvm:
+    type: bool
+    description:
+      - Request the use of full virtualization.
+    """
+
+    OPTIONS_PARAVIRT = """
+options:
+  paravirt:
+    type: bool
+    description:
+      - This guest should be a paravirtualized guest.
+    """
+
+    OPTIONS_CONTAINER = """
+options:
+  container:
+    type: bool
+    description:
+      - This guest should be a container type guest.
+    """
+
+    OPTIONS_CONTROLLER_DEVICES = """
+options:
+  controller:
+    type: dict
+    description:
+      - Attach a controller device to the guest.
+      - The dictionary contains key/value pairs that define individual controller properties.
+      - Examples include I(type=usb,model=none) to disable USB, or I(type=scsi,model=virtio-scsi) for VirtIO SCSI.
+  controller_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple controller devices for the guest.
+    """
+
+    OPTIONS_INPUT_DEVICES = """
+options:
+  input:
+    type: dict
+    description:
+      - Attach an input device to the guest.
+      - Input device types include mouse, tablet, or keyboard.
+      - The dictionary contains key/value pairs that define individual input device properties.
+  input_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple input devices for the guest.
+    """
+
+    OPTIONS_HOST_DEVICES = """
+options:
+  hostdev:
+    type: dict
+    description:
+      - Attach a physical host device to the guest.
+      - The dictionary contains key/value pairs that define individual host device properties.
+  host_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple host devices for the guest.
+    """
+
+    OPTIONS_SOUND_DEVICES = """
+options:
+  sound:
+    type: dict
+    description:
+      - Attach a virtual audio device to the guest.
+      - The dictionary contains key/value pairs that define individual sound device properties.
+      - Common properties include I(model) (e.g. V(ich6), V(ich9), V(ac97)).
+  sound_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple sound devices for the guest.
+    """
+
+    OPTIONS_AUDIO_DEVICES = """
+options:
+  audio:
+    type: dict
+    description:
+      - Configure host audio output for the guest's sound hardware.
+      - The dictionary contains key/value pairs that define individual audio backend properties.
+  audio_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple audio backends for the guest.
+    """
+
+    OPTIONS_WATCHDOG_DEVICES = """
+options:
+  watchdog:
+    type: dict
+    description:
+      - Attach a virtual hardware watchdog device to the guest.
+      - The dictionary contains key/value pairs that define individual watchdog properties.
+  watchdog_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple watchdog devices for the guest.
+    """
+
+    OPTIONS_SERIAL_DEVICES = """
+options:
+  serial:
+    type: dict
+    description:
+      - Attach a serial device to the guest with various redirection options.
+      - The dictionary contains key/value pairs that define individual serial device properties.
+  serial_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple serial devices for the guest.
+    """
+
+    OPTIONS_PARALLEL_DEVICES = """
+options:
+  parallel:
+    type: dict
+    description:
+      - Attach a parallel device to the guest.
+      - The dictionary contains key/value pairs that define individual parallel device properties.
+  parallel_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple parallel devices for the guest.
+    """
+
+    OPTIONS_CHANNEL_DEVICES = """
+options:
+  channel:
+    type: dict
+    description:
+      - Attach a communication channel device to connect the guest and host machine.
+      - The dictionary contains key/value pairs that define individual channel properties.
+  channel_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple channel devices for the guest.
+    """
+
+    OPTIONS_CONSOLE_DEVICES = """
+options:
+  console:
+    type: dict
+    description:
+      - Connect a text console between the guest and host.
+      - The dictionary contains key/value pairs that define individual console properties.
+      - Common properties include I(type) and I(target) for different console types.
+  console_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple console devices for the guest.
+    """
+
+    OPTIONS_VIDEO_DEVICES = """
+options:
+  video:
+    type: dict
+    description:
+      - Specify what video device model will be attached to the guest.
+      - The dictionary contains key/value pairs that define individual video device properties.
+  video_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple video devices for the guest.
+    """
+
+    OPTIONS_SMARTCARD_DEVICES = """
+options:
+  smartcard:
+    type: dict
+    description:
+      - Configure a virtual smartcard device.
+      - The dictionary contains key/value pairs that define individual smartcard properties.
+  smartcard_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple smartcard devices for the guest.
+    """
+
+    OPTIONS_REDIRECTED_DEVICES = """
+options:
+  redirdev:
+    type: dict
+    description:
+      - Add a redirected device for USB or other device redirection.
+      - The dictionary contains key/value pairs that define individual redirection properties.
+      - Common properties include I(bus=usb), I(type=tcp) or I(type=spicevmc).
+  redirected_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple redirected devices for the guest.
+    """
+
+    OPTIONS_MEMBALLOON_DEVICES = """
+options:
+  memballoon:
+    type: dict
+    description:
+      - Attach a virtual memory balloon device to the guest.
+      - The dictionary contains key/value pairs that define individual memory balloon properties.
+      - Common properties include I(model) (e.g. V(virtio), V(xen)).
+  memballoon_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple memory balloon devices for the guest.
+    """
+
+    OPTIONS_TPM_DEVICES = """
+options:
+  tpm:
+    type: dict
+    description:
+      - Configure a virtual TPM (Trusted Platform Module) device.
+      - The dictionary contains key/value pairs that define individual TPM properties.
+  tpm_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple TPM devices for the guest.
+    """
+
+    OPTIONS_RNG_DEVICES = """
+options:
+  rng:
+    type: dict
+    description:
+      - Configure a virtual random number generator (RNG) device.
+      - The dictionary contains key/value pairs that define individual RNG properties.
+  rng_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple RNG devices for the guest.
+    """
+
+    OPTIONS_PANIC_DEVICES = """
+options:
+  panic:
+    type: dict
+    description:
+      - Attach a panic notifier device to the guest.
+      - The dictionary contains key/value pairs that define individual panic device properties.
+  panic_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple panic devices for the guest.
+    """
+
+    OPTIONS_SHMEM_DEVICES = """
+options:
+  shmem:
+    type: dict
+    description:
+      - Attach a shared memory device to the guest.
+      - The dictionary contains key/value pairs that define individual shared memory properties.
+  shmem_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple shared memory devices for the guest.
+    """
+
+    OPTIONS_VSOCK_DEVICES = """
+options:
+  vsock:
+    type: dict
+    description:
+      - Configure a vsock host/guest interface.
+      - The dictionary contains key/value pairs that define individual vsock properties.
+  vsock_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple vsock devices for the guest.
+    """
+
+    OPTIONS_IOMMU_DEVICES = """
+options:
+  iommu:
+    type: dict
+    description:
+      - Add an IOMMU device to the guest.
+      - The dictionary contains key/value pairs that define individual IOMMU properties.
+  iommu_devices:
+    type: list
+    elements: dict
+    description:
+      - Configure multiple IOMMU devices for the guest.
+    """
+
+    OPTIONS_AUTOSTART = """
+options:
+  autostart:
+    type: bool
+    description:
+      - Set the autostart flag for a domain.
+    """
+
+    OPTIONS_TRANSIENT = """
+options:
+  transient:
+    type: bool
+    description:
+      - If set to V(true), libvirt forgets the XML configuration of the VM after shutdown or host restart.
+    """
+
+    OPTIONS_DESTROY_ON_EXIT = """
+options:
+  destroy_on_exit:
+    type: bool
+    description:
+      - If set to V(true), the VM will be destroyed when the console window is exited.
+    """
+
+    OPTIONS_NOREBOOT = """
+options:
+  noreboot:
+    type: bool
+    description:
+      - If set to V(true), the VM will not automatically reboot after the install has completed.
+    """

--- a/plugins/module_utils/libvirt.py
+++ b/plugins/module_utils/libvirt.py
@@ -22,6 +22,10 @@ else:
     HAS_XML = True
 
 
+VIRT_FAILED = 1
+VIRT_SUCCESS = 0
+VIRT_UNAVAILABLE = 2
+
 VIRT_STATE_NAME_MAP = {
     0: 'running',
     1: 'running',

--- a/plugins/module_utils/qemu.py
+++ b/plugins/module_utils/qemu.py
@@ -1,0 +1,171 @@
+# (c) 2025, Joey Zhang <thinkdoggie@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+
+class QemuImgTool(object):
+    """
+    A wrapper for invoking qemu-img command-line tool.
+    """
+
+    def __init__(self, module,
+                 qemu_img_path=None):
+        self.module = module
+        self.warnings = []
+        self._base_command = qemu_img_path if qemu_img_path is not None else 'qemu-img'
+        self.command_argv = [self._base_command]
+
+    def _reset_command(self):
+        """Reset command_argv to base command for new operation"""
+        self.command_argv = [self._base_command]
+
+    def _add_flag(self, flag):
+        """Add a flag to the command line"""
+        self.command_argv.append(flag)
+
+    def _add_option(self, flag, value):
+        """Add an option with value to the command line"""
+        if value is not None:
+            self.command_argv.append(flag)
+            self.command_argv.append(str(value))
+
+    def _add_option_list(self, flag, value_list):
+        """Add multiple values for an option"""
+        if value_list:
+            for value in value_list:
+                if value is not None:
+                    self.command_argv.append(flag)
+                    self.command_argv.append(str(value))
+
+    def convert(self, filename, output_filename,
+                source_format=None, output_format=None,
+                compressed=False, sparse_size=None, num_coroutines=None):
+        """
+        Build and execute qemu-img convert command
+
+        This operation creates a new image file and respects check_mode.
+        In check_mode, the command is built but not executed.
+        """
+        self._reset_command()
+        self.command_argv.append('convert')
+
+        if source_format:
+            self._add_option('-f', source_format)
+
+        if output_format:
+            self._add_option('-O', output_format)
+
+        if compressed:
+            self._add_flag('-c')
+
+        if sparse_size:
+            self._add_option('-S', sparse_size)
+
+        if num_coroutines:
+            self._add_option('-m', num_coroutines)
+
+        # Add disk image filename
+        self.command_argv.append(str(filename))
+
+        # Add output filename (must be last)
+        self.command_argv.append(str(output_filename))
+
+        # Check if we're in check mode
+        if self.module.check_mode:
+            # In check mode, don't execute the command but return success
+            return 0, "Would convert image from %s to %s" % (filename, output_filename), ""
+
+        # Execute the command
+        rc, stdout, stderr = self.module.run_command(
+            self.command_argv, check_rc=False)
+
+        return rc, stdout, stderr
+
+    def info(self, filename, source_format=None,
+             backing_chain=False):
+        """
+        Build and execute qemu-img info command
+
+        This operation is read-only and does not respect check_mode
+        as it doesn't modify the system state.
+        """
+        self._reset_command()
+        self.command_argv.append('info')
+
+        if source_format:
+            self._add_option('-f', source_format)
+
+        if backing_chain:
+            self._add_flag('--backing-chain')
+
+        self._add_option('--output', "json")
+        # Add disk image filename
+        self.command_argv.append(str(filename))
+
+        # Execute the command
+        rc, stdout, stderr = self.module.run_command(
+            self.command_argv, check_rc=False)
+
+        # Parse output based on format
+        parsed_output = dict()
+        if rc == 0 and stdout.strip():
+            try:
+                parsed_output = json.loads(stdout)
+            except ValueError as e:
+                # If JSON parsing fails, add warning
+                self.warnings.append(
+                    "Failed to parse JSON output: %s" % str(e))
+
+        return rc, parsed_output, stderr
+
+    def resize(self, filename, size, source_format=None,
+               preallocation=None, shrink=False):
+        """
+        Build and execute qemu-img resize command
+
+        This operation modifies an existing image file and respects check_mode.
+        In check_mode, the command is built but not executed.
+
+        Args:
+            filename (str): Image file path
+            size (str): New size with optional +/- prefix and size suffixes (k, M, G, T)
+                       Examples: '10G', '+1G', '-500M'
+            source_format (str): Disk image format (auto-detected if None)
+            preallocation (str): Preallocation mode ('off', 'metadata', 'falloc', 'full')
+            shrink (bool): Allow shrinking (required for size reduction)
+
+        Returns:
+            tuple: (rc, stdout, stderr)
+        """
+        self._reset_command()
+        self.command_argv.append('resize')
+
+        if source_format:
+            self._add_option('-f', source_format)
+
+        if preallocation:
+            self._add_option('--preallocation', preallocation)
+
+        if shrink:
+            self._add_flag('--shrink')
+
+        # Add disk image filename
+        self.command_argv.append(str(filename))
+
+        # Add size (must be last)
+        self.command_argv.append(str(size))
+
+        # Check if we're in check mode
+        if self.module.check_mode:
+            # In check mode, don't execute the command but return success
+            return 0, "Would resize image %s to %s" % (filename, size), ""
+
+        # Execute the command
+        rc, stdout, stderr = self.module.run_command(
+            self.command_argv, check_rc=False)
+
+        return rc, stdout, stderr

--- a/plugins/module_utils/virt_install.py
+++ b/plugins/module_utils/virt_install.py
@@ -4,8 +4,16 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
+import tempfile
+import math
 
-from ansible_collections.community.libvirt.plugins.module_utils.libvirt import LibvirtConnection
+from ansible_collections.community.libvirt.plugins.module_utils.libvirt import (
+    LibvirtConnection, VIRT_SUCCESS
+)
+
+
+OPTION_BOOL_ONOFF = 1
 
 
 class LibvirtWrapper(object):
@@ -22,6 +30,11 @@ class LibvirtWrapper(object):
         self.__get_conn()
         return self.conn.find_vm(vmid)
 
+    def create(self, vmid):
+        if not self.module.check_mode:
+            self.__get_conn()
+            return self.conn.create(vmid)
+
     def shutdown(self, vmid):
         if not self.module.check_mode:
             self.__get_conn()
@@ -37,3 +50,1618 @@ class LibvirtWrapper(object):
             self.__get_conn()
             self.conn.delete_domain_volumes(vmid)
             return self.conn.undefine(vmid, 0)
+
+
+def _get_option_mapping(key, mapping):
+    if mapping is None:
+        return (key, None)
+
+    if key in mapping:
+        name, valmap = mapping[key]
+        if name is None:
+            name = key
+        return (name, valmap)
+    else:
+        return (key, None)
+
+
+def _dict2options(obj, mapping, prefix=""):
+
+    if obj is None:
+        return ""
+
+    if not isinstance(obj, dict):
+        return str(obj)
+
+    parts = []
+    for k, v in obj.items():
+        if v is None:
+            continue
+
+        name, valmap = _get_option_mapping(k, mapping)
+
+        if isinstance(v, dict):
+            sub_prefix = "{}{}.".format(prefix, name)
+            parts.append(_dict2options(v, valmap, prefix=sub_prefix))
+        elif isinstance(v, list):
+            for i, item in enumerate(v):
+                item_name = "{}{}{}".format(prefix, name, i)
+                if isinstance(item, dict):
+                    sub_prefix = "{}.".format(item_name)
+                    parts.append(
+                        _dict2options(
+                            item,
+                            valmap,
+                            prefix=sub_prefix))
+                elif isinstance(item, bool):
+                    if valmap == OPTION_BOOL_ONOFF:
+                        parts.append(
+                            "{}={}".format(
+                                item_name,
+                                'on' if item else 'off'))
+                    else:
+                        parts.append(
+                            "{}={}".format(
+                                item_name,
+                                'yes' if item else 'no'))
+                else:
+                    parts.append("{}={}".format(item_name, str(item)))
+        elif isinstance(v, bool):
+            if valmap == OPTION_BOOL_ONOFF:
+                parts.append(
+                    "{}{}={}".format(
+                        prefix,
+                        name,
+                        'on' if v else 'off'))
+            else:
+                parts.append(
+                    "{}{}={}".format(
+                        prefix,
+                        name,
+                        'yes' if v else 'no'))
+        else:
+            parts.append("{}{}={}".format(prefix, name, str(v)))
+
+    if parts:
+        return ",".join(parts)
+    else:
+        return ""
+
+
+class VirtInstallTool(object):
+
+    def __init__(self, module,
+                 virtinst_path=None):
+        self.module = module
+        self.params = module.params.copy()
+        self.warnings = []
+        self._base_command = virtinst_path if virtinst_path is not None else 'virt-install'
+        self.command_argv = [self._base_command]
+
+        self._vm_name = self.params.get('name')
+
+    def _reset_command(self):
+        """Reset command_argv to base command for new operation"""
+        self.command_argv = [self._base_command]
+
+    def _save_string_to_tempfile(self, content, suffix='.tmp'):
+        fd, path = tempfile.mkstemp(dir=self.module.tmpdir,
+                                    suffix=suffix,
+                                    text=True)
+        with os.fdopen(fd, 'w') as f:
+            f.write(content)
+
+        return path
+
+    def _add_parameter(
+            self,
+            flag,
+            primary_value=None,
+            dict_value=None,
+            dict_mapping=None):
+        """Add a command line option to virt-install command"""
+        if primary_value:
+            if dict_value:
+                self.command_argv.append("{}".format(flag))
+                self.command_argv.append(
+                    "{},{}".format(
+                        str(primary_value),
+                        _dict2options(
+                            dict_value,
+                            dict_mapping)))
+                return
+            else:
+                self.command_argv.append("{}".format(flag))
+                self.command_argv.append("{}".format(str(primary_value)))
+                return
+        else:
+            if dict_value:
+                self.command_argv.append("{}".format(flag))
+                self.command_argv.append("{}".format(
+                    _dict2options(dict_value, dict_mapping)))
+                return
+            else:
+                self.command_argv.append("{}".format(flag))
+                return
+
+    def _add_flag_parameter(self, flag, value):
+        """Add a flag command line option to virt-install command"""
+        if value:
+            self.command_argv.append("{}".format(flag))
+            return
+
+    def _get_param_combined_items(self, singular_key, plural_key):
+        combined_items = []
+        if self.params.get(singular_key) is not None:
+            combined_items.append(self.params[singular_key])
+        if self.params.get(plural_key) is not None:
+            combined_items.extend(self.params[plural_key])
+
+        return combined_items
+
+    def _build_basic_options(self):
+        """Build basic VM configuration options"""
+        # Required options
+        if self.params.get('uri') is not None:
+            self._add_parameter('--connect', self.params['uri'])
+
+        if self.params.get('name') is not None:
+            self._add_parameter('--name', self.params['name'])
+
+        if self.params.get('memory') is not None:
+            memory_mapping = {
+                'current_memory': ('currentMemory', None),
+                'max_memory': ('maxMemory', None),
+                'max_memory_opts': ('maxMemory', None),
+            }
+            self._add_parameter('--memory', self.params['memory'],
+                                dict_value=self.params.get('memory_opts'),
+                                dict_mapping=memory_mapping)
+
+        if self.params.get('memorybacking') is not None:
+            memorybacking_mapping = {
+                'hugepage_specs': ('hugepages.page', {
+                    'page_size': ('size', None),
+                }),
+            }
+            self._add_parameter('--memorybacking',
+                                dict_value=self.params['memorybacking'],
+                                dict_mapping=memorybacking_mapping)
+
+        if self.params.get('arch') is not None:
+            self._add_parameter('--arch', self.params['arch'])
+
+        if self.params.get('machine') is not None:
+            self._add_parameter('--machine', self.params['machine'])
+
+        if self.params.get('metadata') is not None:
+            self._add_parameter('--metadata', self.params['metadata'])
+
+        if self.params.get('events') is not None:
+            self._add_parameter('--events',
+                                dict_value=self.params['events'])
+
+        if self.params.get('resource') is not None:
+            self._add_parameter('--resource', self.params['resource'])
+
+        if self.params.get('sysinfo') is not None:
+            self._add_parameter('--sysinfo', self.params['sysinfo'])
+
+        if self.params.get('qemu_commandline') is not None:
+            self._add_parameter(
+                '--qemu-commandline',
+                self.params['qemu_commandline'])
+
+        if self.params.get('vcpus') is not None:
+            vcpus_mapping = {
+                'current': ('vcpu.current', None),
+                'placement': ('vcpu.placement', None),
+                'vcpu_specs': ('vcpus.vcpu', None),
+            }
+            self._add_parameter('--vcpus', self.params['vcpus'],
+                                dict_value=self.params.get('vcpus_opts'),
+                                dict_mapping=vcpus_mapping)
+
+        if self.params.get('numatune') is not None:
+            numatune_mapping = {
+                'memnode_specs': ('memnode', None)
+            }
+            self._add_parameter('--numatune',
+                                dict_value=self.params['numatune'],
+                                dict_mapping=numatune_mapping)
+
+        if self.params.get('memtune') is not None:
+            self._add_parameter('--memtune', dict_value=self.params['memtune'])
+
+        if self.params.get('blkiotune') is not None:
+            blkiotune_mapping = {
+                'devices': ('device', None)
+            }
+            self._add_parameter('--blkiotune',
+                                dict_value=self.params['blkiotune'],
+                                dict_mapping=blkiotune_mapping)
+
+        if self.params.get('cpu') is not None:
+            cpu_mapping = {
+                'model_opts': ('model', None),
+                'numa': (None, {
+                    'cell_specs': ('cell', {
+                        'mem_access': ('memAccess', None),
+                        'distances': (None, {
+                            'sibling_specs': ('sibling', None)
+                        }),
+                        'cache_specs': ('cache', None)
+                    }),
+                    'interconnects': (None, {
+                        'bandwidth_specs': ('bandwidth', None),
+                        'latency_specs': ('latency', None)
+                    })
+                })
+            }
+            cpu_dict_value = self.params['cpu']
+            cpu_primary_argv = []
+            if 'model' in cpu_dict_value:
+                cpu_model = cpu_dict_value.pop('model')
+                if cpu_model:
+                    cpu_primary_argv.append(cpu_model)
+            if 'features' in cpu_dict_value:
+                cpu_feature_param = cpu_dict_value.pop('features')
+                if cpu_feature_param:
+                    for k, v in cpu_feature_param.items():
+                        if v in [
+                            'force',
+                            'require',
+                            'optional',
+                            'disable',
+                                'forbid']:
+                            cpu_primary_argv.append("{}={}".format(v, k))
+            if cpu_primary_argv:
+                cpu_primary_value = ','.join(cpu_primary_argv)
+                self._add_parameter('--cpu', cpu_primary_value,
+                                    dict_value=cpu_dict_value,
+                                    dict_mapping=cpu_mapping)
+            else:
+                self._add_parameter('--cpu',
+                                    dict_value=cpu_dict_value,
+                                    dict_mapping=cpu_mapping)
+
+        if self.params.get('cputune') is not None:
+            cputune_mapping = {
+                'vcpupin_specs': ('vcpupin', None),
+                'iothreadpin_specs': ('iothreadpin', None),
+                'vcpusched_specs': ('vcpusched', None),
+                'iothreadsched_specs': ('iothreadsched', None),
+            }
+            self._add_parameter('--cputune',
+                                dict_value=self.params['cputune'],
+                                dict_mapping=cputune_mapping)
+
+        if self.params.get('security') is not None:
+            self._add_parameter(
+                '--seclabel',
+                dict_value=self.params['security'])
+
+        if self.params.get('keywrap') is not None:
+            keywrap_mapping = {
+                'ciphers': ('cipher', None)
+            }
+            self._add_parameter('--keywrap',
+                                dict_value=self.params['keywrap'],
+                                dict_mapping=keywrap_mapping)
+
+        if self.params.get('iothreads') is not None:
+            iothreads_mapping = {
+                'iothread_specs': ('iothreadids.iothread', None),
+            }
+            self._add_parameter('--iothreads', self.params['iothreads'],
+                                dict_value=self.params.get('iothreads_opts'),
+                                dict_mapping=iothreads_mapping)
+
+        if self.params.get('features') is not None:
+            self._add_parameter(
+                '--features',
+                dict_value=self.params['features'])
+
+        if self.params.get('clock') is not None:
+            clock_mapping = {
+                'timers': ('timer', None)
+            }
+            self._add_parameter('--clock',
+                                dict_value=self.params['clock'],
+                                dict_mapping=clock_mapping)
+
+        if self.params.get('pm') is not None:
+            self._add_parameter('--pm',
+                                dict_value=self.params['pm'])
+
+        if self.params.get('launch_security') is not None:
+            launch_security_mapping = {
+                'dh_cert': ('dhCert', None),
+                'reduced_phys_bits': ('reducedPhysBits', None)
+            }
+            self._add_parameter('--launchSecurity',
+                                dict_value=self.params['launch_security'],
+                                dict_mapping=launch_security_mapping)
+
+    def _build_installation_options(self):        # Installation media options
+        if self.params.get('cdrom') is not None:
+            self._add_parameter('--cdrom', self.params['cdrom'])
+
+        if self.params.get('location') is not None:
+            self._add_parameter('--location', self.params['location'],
+                                dict_value=self.params.get('location_opts'))
+
+        if self.params.get('pxe') is not None:
+            self._add_flag_parameter('--pxe', self.params['pxe'])
+
+        if self.params.get('import'):
+            self._add_flag_parameter('--import', self.params['import'])
+
+        if self.params.get('extra_args') is not None:
+            self._add_parameter('--extra-args', self.params['extra_args'])
+
+        if self.params.get('initrd_inject') is not None:
+            self._add_parameter(
+                '--initrd-inject',
+                self.params['initrd_inject'])
+
+        if self.params.get('install') is not None:
+            self._add_parameter('--install',
+                                dict_value=self.params['install'])
+
+        if self.params.get('unattended') is not None:
+            unattended_mapping = {
+                'admin_password_file': ('admin-password-file', None),
+                'user_login': ('user-login', None),
+                'user_password_file': ('user-password-file', None),
+                'product_key': ('product-key', None),
+            }
+            self._add_parameter('--unattended',
+                                dict_value=self.params['unattended'],
+                                dict_mapping=unattended_mapping)
+
+        if self.params.get('cloud_init') is not None:
+            cloud_init_params = self.params['cloud_init'].copy()
+
+            if cloud_init_params.get('network_config'):
+                network_config_content = cloud_init_params['network_config']
+                cloud_init_params['network-config'] = self._save_string_to_tempfile(network_config_content)
+                del cloud_init_params['network_config']
+            if cloud_init_params.get('meta_data'):
+                meta_data_content = cloud_init_params['meta_data']
+                cloud_init_params['meta-data'] = self._save_string_to_tempfile(meta_data_content)
+                del cloud_init_params['meta_data']
+            if cloud_init_params.get('user_data'):
+                user_data_content = cloud_init_params['user_data']
+                cloud_init_params['user-data'] = self._save_string_to_tempfile(user_data_content)
+                del cloud_init_params['user_data']
+
+            cloud_init_mapping = {
+                'root_password_generate': (
+                    'root-password-generate',
+                    OPTION_BOOL_ONOFF),
+                'disable': (
+                    'disable',
+                    OPTION_BOOL_ONOFF),
+                'root_password_file': (
+                    'root-password-file',
+                    None),
+                'root_ssh_key': (
+                    'root-ssh-key',
+                    None),
+                'clouduser_ssh_key': (
+                    'clouduser-ssh-key',
+                    None),
+            }
+            self._add_parameter('--cloud-init',
+                                dict_value=cloud_init_params,
+                                dict_mapping=cloud_init_mapping)
+
+        if self.params.get('boot') is not None:
+            self._add_parameter('--boot', self.params['boot'],
+                                dict_value=self.params.get('boot_opts'))
+
+        if self.params.get('idmap') is not None:
+            self._add_parameter('--idmap',
+                                dict_value=self.params['idmap'])
+
+    def _build_guest_os_options(self):
+        if self.params.get('osinfo') is not None:
+            osinfo_mapping = {
+                'detect': ('detect', OPTION_BOOL_ONOFF),
+                'require': ('require', OPTION_BOOL_ONOFF),
+            }
+            self._add_parameter('--osinfo',
+                                dict_value=self.params['osinfo'],
+                                dict_mapping=osinfo_mapping)
+
+    def _build_storage_options(self):
+        if self.params.get('disks') is not None:
+            disk_mapping = {
+                'backing_store': ('backing_store', None),
+                'backing_format': ('backing_format', None),
+                'transient_opts': ('transient', {
+                    'share_backing': ('shareBacking', None)
+                })
+            }
+            for disk in self.params['disks']:
+                self._add_parameter('--disk',
+                                    dict_value=disk,
+                                    dict_mapping=disk_mapping)
+
+        if self.params.get('filesystems') is not None:
+            for filesystem in self.params['filesystems']:
+                self._add_parameter('--filesystem',
+                                    dict_value=filesystem)
+
+    def _build_network_options(self):
+        if self.params.get('networks') is not None:
+            network_param = self.params['networks']
+            if len(network_param) == 0:
+                self._add_parameter('--network', 'none')
+                return
+
+            network_mapping = {
+                'trust_guest_rx_filters': ('trustGuestRxFilters', None),
+                'state': ('link.state', None),
+            }
+            for network in network_param:
+                self._add_parameter('--network',
+                                    dict_value=network,
+                                    dict_mapping=network_mapping)
+
+    def _build_graphics_options(self):
+        graphics_params = self._get_param_combined_items(
+            'graphics', 'graphics_devices')
+
+        if len(graphics_params) == 0:
+            self._add_parameter('--graphics', 'none')
+            return
+
+        for item in graphics_params:
+            graphics_primary_value = None
+            if 'type' in item:
+                graphics_primary_value = item.pop('type')
+                self._add_parameter('--graphics', graphics_primary_value,
+                                    dict_value=item)
+            else:
+                self._add_parameter('--graphics',
+                                    dict_value=item)
+
+    def _build_virt_options(self):
+        if self.params.get('virt_type') is not None:
+            self._add_parameter('--virt-type', self.params['virt_type'])
+
+        if self.params.get('hvm') is not None:
+            self._add_flag_parameter('--hvm', self.params['hvm'])
+
+        if self.params.get('paravirt') is not None:
+            self._add_flag_parameter('--paravirt', self.params['paravirt'])
+
+        if self.params.get('container') is not None:
+            self._add_flag_parameter('--container', self.params['container'])
+
+    def _build_device_options(self):
+        # Controller devices
+        controller_params = self._get_param_combined_items(
+            'controller', 'controller_devices')
+        for item in controller_params:
+            self._add_parameter('--controller',
+                                dict_value=item)
+
+        # Input devices
+        input_params = self._get_param_combined_items('input', 'input_devices')
+        for item in input_params:
+            self._add_parameter('--input',
+                                dict_value=item)
+
+        # Host devices
+        hostdev_params = self._get_param_combined_items(
+            'hostdev', 'host_devices')
+        for item in hostdev_params:
+            self._add_parameter('--hostdev',
+                                dict_value=item)
+
+        # Sound devices
+        sound_params = self._get_param_combined_items('sound', 'sound_devices')
+        for item in sound_params:
+            self._add_parameter('--sound',
+                                dict_value=item)
+
+        # Audio devices
+        audio_params = self._get_param_combined_items('audio', 'audio_devices')
+        for item in audio_params:
+            self._add_parameter('--audio',
+                                dict_value=item)
+
+        # Watchdog devices
+        watchdog_params = self._get_param_combined_items(
+            'watchdog', 'watchdog_devices')
+        for item in watchdog_params:
+            self._add_parameter('--watchdog',
+                                dict_value=item)
+
+        # Serial devices
+        serial_params = self._get_param_combined_items(
+            'serial', 'serial_devices')
+        for item in serial_params:
+            self._add_parameter('--serial',
+                                dict_value=item)
+
+        # Parallel devices
+        parallel_params = self._get_param_combined_items(
+            'parallel', 'parallel_devices')
+        for item in parallel_params:
+            self._add_parameter('--parallel',
+                                dict_value=item)
+
+        # Channel devices
+        channel_params = self._get_param_combined_items(
+            'channel', 'channel_devices')
+        for item in channel_params:
+            self._add_parameter('--channel',
+                                dict_value=item)
+
+        # Console devices
+        console_params = self._get_param_combined_items(
+            'console', 'console_devices')
+        for item in console_params:
+            self._add_parameter('--console',
+                                dict_value=item)
+
+        # Video devices
+        video_params = self._get_param_combined_items('video', 'video_devices')
+        for item in video_params:
+            self._add_parameter('--video',
+                                dict_value=item)
+
+        # Smartcard devices
+        smartcard_params = self._get_param_combined_items(
+            'smartcard', 'smartcard_devices')
+        for item in smartcard_params:
+            self._add_parameter('--smartcard',
+                                dict_value=item)
+
+        # Redirection devices
+        redirdev_params = self._get_param_combined_items(
+            'redirdev', 'redirected_devices')
+        for item in redirdev_params:
+            self._add_parameter('--redirdev',
+                                dict_value=item)
+
+        # Memory balloon devices
+        memballoon_params = self._get_param_combined_items(
+            'memballoon', 'memballoon_devices')
+        memballoon_mapping = {
+            'freePageReporting': ('freePageReporting', OPTION_BOOL_ONOFF),
+            'autodeflate': ('autodeflate', OPTION_BOOL_ONOFF),
+        }
+        for item in memballoon_params:
+            self._add_parameter('--memballoon',
+                                dict_value=item,
+                                dict_mapping=memballoon_mapping)
+
+        # TPM devices
+        tpm_params = self._get_param_combined_items('tpm', 'tpm_devices')
+        tpm_mapping = {
+            'active_pcr_banks': ('active_pcr_banks', {
+                'sha1': ('sha1', OPTION_BOOL_ONOFF),
+                'sha256': ('sha256', OPTION_BOOL_ONOFF),
+                'sha384': ('sha384', OPTION_BOOL_ONOFF),
+                'sha512': ('sha512', OPTION_BOOL_ONOFF),
+            }),
+            'backend': ('backend', {
+                'persistent_state': ('persistent_state', OPTION_BOOL_ONOFF),
+            }),
+        }
+        for item in tpm_params:
+            self._add_parameter('--tpm',
+                                dict_value=item,
+                                dict_mapping=tpm_mapping)
+
+        # RNG devices
+        rng_params = self._get_param_combined_items('rng', 'rng_devices')
+        for item in rng_params:
+            self._add_parameter('--rng',
+                                dict_value=item)
+
+        # Panic devices
+        panic_params = self._get_param_combined_items('panic', 'panic_devices')
+        for item in panic_params:
+            self._add_parameter('--panic',
+                                dict_value=item)
+
+        # Shared memory devices
+        shmem_params = self._get_param_combined_items('shmem', 'shmem_devices')
+        shmem_mapping = {
+            'msi': ('msi', {
+                'ioeventfd': ('ioeventfd', OPTION_BOOL_ONOFF),
+            }),
+        }
+        for item in shmem_params:
+            self._add_parameter('--shmem',
+                                dict_value=item,
+                                dict_mapping=shmem_mapping)
+
+        # Vsock devices
+        vsock_params = self._get_param_combined_items('vsock', 'vsock_devices')
+        vsock_mapping = {
+            'cid': ('cid', {
+                'auto': ('auto', OPTION_BOOL_ONOFF),
+            }),
+        }
+        for item in vsock_params:
+            self._add_parameter('--vsock',
+                                dict_value=item,
+                                dict_mapping=vsock_mapping)
+
+        # IOMMU devices
+        iommu_params = self._get_param_combined_items('iommu', 'iommu_devices')
+        iommu_mapping = {
+            'driver': ('driver', {
+                'caching_mode': ('caching_mode', OPTION_BOOL_ONOFF),
+                'eim': ('eim', OPTION_BOOL_ONOFF),
+                'intremap': ('intremap', OPTION_BOOL_ONOFF),
+                'iotlb': ('iotlb', OPTION_BOOL_ONOFF),
+            }),
+        }
+        for item in iommu_params:
+            self._add_parameter('--iommu',
+                                dict_value=item,
+                                dict_mapping=iommu_mapping)
+
+    def _build_misc_options(self):
+        if self.params.get('autostart') is not None:
+            self._add_flag_parameter('--autostart', self.params['autostart'])
+
+        if self.params.get('transient') is not None:
+            self._add_flag_parameter('--transient', self.params['transient'])
+
+        if self.params.get('destroy_on_exit') is not None:
+            self._add_flag_parameter(
+                '--destroy-on-exit',
+                self.params['destroy_on_exit'])
+
+        if self.params.get('noreboot') is not None:
+            self._add_flag_parameter('--noreboot', self.params['noreboot'])
+
+    def _validate_params(self):
+        """Validate parameter combinations and dependencies according to virt-install requirements"""
+
+        extra_key_pairs = [
+            ('memory', 'memory_opts'),
+            ('vcpus', 'vcpus_opts'),
+            ('location', 'location_opts'),
+            ('boot', 'boot_opts'),
+            ('iothreads', 'iothreads_opts'),
+        ]
+
+        for param_key, extra_key in extra_key_pairs:
+            if (extra_key in self.params) and (param_key not in self.params):
+                self.module.fail_json(
+                    msg="{} requires {} to be specified".format(
+                        extra_key, param_key))
+
+    def _build_command(self):
+        """Build the complete virt-install command"""
+        self._validate_params()
+
+        # Build command sections
+        self._build_basic_options()
+        self._build_installation_options()
+        self._build_guest_os_options()
+        self._build_storage_options()
+        self._build_network_options()
+        self._build_graphics_options()
+        self._build_virt_options()
+        self._build_device_options()
+        self._build_misc_options()
+
+        # Always add --noautoconsole for non-interactive execution
+        self.command_argv.append('--noautoconsole')
+
+    def execute(self, dryrun=False, wait_timeout=None):
+        changed = False
+        result = dict()
+
+        self._reset_command()
+        self._build_command()
+
+        if dryrun:
+            self.command_argv.append('--dry-run')
+
+        if wait_timeout:
+            wait_minutes = math.ceil(wait_timeout / 60.0)
+            self.command_argv.append('--wait')
+            self.command_argv.append(str(wait_minutes))
+
+        # Execute the command
+        rc, stdout, stderr = self.module.run_command(
+            self.command_argv, check_rc=False)
+
+        if rc == 0:
+            changed = True
+            result["msg"] = "virtual machine '{}' created successfully".format(
+                self._vm_name
+            )
+            return changed, VIRT_SUCCESS, result
+
+        error_msg = "failed to create virtual machine '{}': {}".format(
+            self._vm_name, stderr.strip() if stderr else stdout.strip()
+        )
+        result["msg"] = error_msg
+        return changed, rc, result
+
+
+def get_memory_args():
+    return dict(
+        memory=dict(type='int'),
+        memory_opts=dict(
+            type='dict',
+            options=dict(
+                current_memory=dict(type='int'),
+                max_memory=dict(type='int'),
+                max_memory_opts=dict(
+                    type='dict', options=dict(
+                        slots=dict(
+                            type='int'))),
+            ),
+        ),
+    )
+
+
+def get_memorybacking_args():
+    return dict(
+        memorybacking=dict(
+            type='dict',
+            options=dict(
+                hugepages=dict(type='bool'),
+                hugepage_specs=dict(
+                    type='list',
+                    elements="dict",
+                    options=dict(
+                        page_size=dict(
+                            type='int'), nodeset=dict(
+                            type='str')),
+                ),
+                nosharepages=dict(type='bool'),
+                locked=dict(type='bool'),
+                access=dict(
+                    type='dict',
+                    options=dict(
+                        mode=dict(
+                            type='str',
+                            choices=[
+                                'shared',
+                                'private'])),
+                ),
+                allocation=dict(
+                    type='dict',
+                    options=dict(
+                        mode=dict(
+                            type='str', choices=[
+                                'immediate', 'ondemand']),
+                        threads=dict(type='int'),
+                    ),
+                ),
+                discard=dict(type='bool'),
+            ),
+        ),
+    )
+
+
+def get_arch_args():
+    return dict(
+        arch=dict(type='str'),
+    )
+
+
+def get_machine_args():
+    return dict(
+        machine=dict(type='str'),
+    )
+
+
+def get_metadata_args():
+    return dict(
+        metadata=dict(type='dict'),
+    )
+
+
+def get_events_args():
+    return dict(
+        events=dict(
+            type='dict',
+            options=dict(
+                on_poweroff=dict(
+                    type='str',
+                    choices=[
+                        'destroy',
+                        'restart',
+                        'preserve',
+                        'rename-restart'],
+                ),
+                on_reboot=dict(
+                    type='str',
+                    choices=[
+                        'destroy',
+                        'restart',
+                        'preserve',
+                        'rename-restart'],
+                ),
+                on_crash=dict(
+                    type='str',
+                    choices=[
+                        'destroy',
+                        'restart',
+                        'preserve',
+                        'rename-restart',
+                        'coredump-destroy',
+                        'coredump-restart',
+                    ],
+                ),
+                on_lockfailure=dict(
+                    type='str', choices=['poweroff', 'restart', 'pause', 'ignore']
+                ),
+            ),
+        ),
+    )
+
+
+def get_resource_args():
+    return dict(
+        resource=dict(type='dict'),
+    )
+
+
+def get_sysinfo_args():
+    return dict(
+        sysinfo=dict(type='dict'),
+    )
+
+
+def get_qmeu_commandline_args():
+    return dict(
+        qemu_commandline=dict(type='str'),
+    )
+
+
+def get_vcpu_args():
+    return dict(
+        vcpus=dict(type='int'),
+        vcpus_opts=dict(
+            type='dict',
+            options=dict(
+                maxvcpus=dict(type='int'),
+                sockets=dict(type='int'),
+                dies=dict(type='int'),
+                clusters=dict(type='int'),
+                cores=dict(type='int'),
+                threads=dict(type='int'),
+                current=dict(type='int'),
+                cpuset=dict(type='str'),
+                placement=dict(type='str', choices=['static', 'auto']),
+                vcpu_specs=dict(type='list', elements="dict"),
+            ),
+        ),
+    )
+
+
+def get_numatune_args():
+    return dict(
+        numatune=dict(
+            type='dict',
+            options=dict(
+                memory=dict(
+                    type='dict',
+                    options=dict(
+                        mode=dict(
+                            type='str', choices=['interleave', 'preferred', 'strict']
+                        ),
+                        nodeset=dict(type='str'),
+                        placement=dict(type='str', choices=['static', 'auto']),
+                    ),
+                ),
+                memnode_specs=dict(
+                    type='list',
+                    elements="dict",
+                    options=dict(
+                        cellid=dict(type='int'),
+                        mode=dict(
+                            type='str', choices=['interleave', 'preferred', 'strict']
+                        ),
+                        nodeset=dict(type='str'),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def get_memtune_args():
+    return dict(
+        memtune=dict(type='dict'),
+    )
+
+
+def get_blkiotune_args():
+    return dict(
+        blkiotune=dict(
+            type='dict',
+            options=dict(
+                weight=dict(type='int'), devices=dict(type='list', elements="dict")
+            ),
+        ),
+    )
+
+
+def get_cpu_args():
+    return dict(
+        cpu=dict(
+            type='dict',
+            options=dict(
+                model=dict(type='str'),
+                model_opts=dict(
+                    type='dict',
+                    options=dict(
+                        fallback=dict(type='str', choices=['forbid', 'allow']),
+                        vendor_id=dict(type='str'),
+                    ),
+                ),
+                match=dict(type='str', choices=['exact', 'minimum', 'strict']),
+                migratable=dict(type='bool'),
+                vendor=dict(type='str'),
+                features=dict(type='dict'),
+                cache=dict(
+                    type='dict',
+                    options=dict(
+                        mode=dict(
+                            type='str', choices=['emulate', 'passthrough', 'disable']
+                        ),
+                        level=dict(type='int'),
+                    ),
+                ),
+                numa=dict(
+                    type='dict',
+                    options=dict(
+                        cell_specs=dict(
+                            type='list',
+                            elements="dict",
+                            options=dict(
+                                id=dict(type='int'),
+                                cpus=dict(type='str'),
+                                memory=dict(type='int'),
+                                mem_access=dict(
+                                    type='str', choices=[
+                                        'shared', 'private']),
+                                discard=dict(type='bool'),
+                                distances=dict(
+                                    type='dict',
+                                    options=dict(
+                                        sibling_specs=dict(
+                                            type='list', elements="dict"),
+                                    ),
+                                ),
+                                cache_specs=dict(type='list', elements="dict"),
+                            ),
+                        ),
+                        interconnects=dict(
+                            type='list',
+                            elements="dict",
+                            options=dict(
+                                bandwidth_specs=dict(
+                                    type='list', elements="dict"),
+                                latency_specs=dict(
+                                    type='list', elements="dict"),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def get_cputune_args():
+    return dict(
+        cputune=dict(
+            type='dict',
+            options=dict(
+                vcpupin_specs=dict(
+                    type='list',
+                    elements="dict",
+                    options=dict(
+                        vcpu=dict(type='int'),
+                        cpuset=dict(type='str'),
+                    ),
+                ),
+                emulatorpin=dict(
+                    type='dict',
+                    options=dict(
+                        cpuset=dict(type='str'),
+                    )
+                ),
+                iothreadpin_specs=dict(
+                    type='list',
+                    elements="dict",
+                    options=dict(
+                        iothread=dict(type='int'),
+                        cpuset=dict(type='str'),
+                    ),
+                ),
+                vcpusched_specs=dict(
+                    type='list',
+                    elements="dict",
+                    options=dict(
+                        vcpus=dict(type='str'),
+                        scheduler=dict(
+                            type='str', choices=[
+                                'batch', 'idle', 'fifo', 'rr']),
+                        priority=dict(type='int'),
+                    ),
+                ),
+                iothreadsched_specs=dict(
+                    type='list',
+                    elements="dict",
+                    options=dict(
+                        iothreads=dict(type='str'),
+                        scheduler=dict(
+                            type='str', choices=[
+                                'batch', 'idle', 'fifo', 'rr']),
+                        priority=dict(type='int'),
+                    ),
+                ),
+                emulatorsched=dict(
+                    type='dict',
+                    options=dict(
+                        scheduler=dict(
+                            type='str', choices=[
+                                'batch', 'idle', 'fifo', 'rr']),
+                        priority=dict(type='int'),
+                    ),
+                ),
+                shares=dict(type='int'),
+                period=dict(type='int'),
+                quota=dict(type='int'),
+                global_period=dict(type='int'),
+                global_quota=dict(type='int'),
+                emulator_period=dict(type='int'),
+                emulator_quota=dict(type='int'),
+                iothread_period=dict(type='int'),
+                iothread_quota=dict(type='int'),
+            ),
+        ),
+    )
+
+
+def get_security_args():
+    return dict(
+        security=dict(type='dict'),
+    )
+
+
+def get_keywrap_args():
+    return dict(
+        keywrap=dict(
+            type='dict', options=dict(ciphers=dict(type='list', elements="dict")), no_log=True
+        ),
+    )
+
+
+def get_iothreads_args():
+    return dict(
+        iothreads=dict(type='int'),
+        iothreads_opts=dict(
+            type='dict',
+            options=dict(
+                iothread_specs=dict(
+                    type='list',
+                    elements="dict",
+                    options=dict(
+                        id=dict(type='int'),
+                        thread_pool_min=dict(type='int'),
+                        thread_pool_max=dict(type='int'),
+                    ),
+                ),
+                defaultiothread=dict(
+                    type='dict',
+                    options=dict(
+                        thread_pool_min=dict(type='int'),
+                        thread_pool_max=dict(type='int'),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def get_features_args():
+    return dict(
+        features=dict(type='dict'),
+    )
+
+
+def get_clock_args():
+    return dict(
+        clock=dict(
+            type='dict',
+            options=dict(
+                offset=dict(type='str'), timers=dict(type='list', elements="dict")
+            ),
+        ),
+    )
+
+
+def get_pm_args():
+    return dict(
+        pm=dict(
+            type='dict',
+            options=dict(
+                suspend_to_mem=dict(
+                    type='dict', options=dict(enabled=dict(type='bool'))
+                ),
+                suspend_to_disk=dict(
+                    type='dict', options=dict(enabled=dict(type='bool'))
+                ),
+            ),
+        ),
+    )
+
+
+def get_launch_security_args():
+    return dict(
+        launch_security=dict(
+            type='dict',
+            options=dict(
+                type=dict(type='str', required=True),
+                policy=dict(type='str'),
+                cbitpos=dict(type='int'),
+                reduced_phys_bits=dict(type='int'),
+                dh_cert=dict(type='str'),
+                session=dict(type='str'),
+            ),
+        ),
+    )
+
+
+def get_cdrom_args():
+    return dict(
+        cdrom=dict(type='str'),
+    )
+
+
+def get_location_opts():
+    return dict(
+        location=dict(type='str'),
+        location_opts=dict(
+            type='dict', options=dict(kernel=dict(type='str'), initrd=dict(type='str'))
+        ),
+    )
+
+
+def get_pxe_args():
+    return dict(
+        pxe=dict(type='bool'),
+    )
+
+
+def get_extra_args_args():
+    return dict(
+        extra_args=dict(type='str'),
+    )
+
+
+def get_initrd_inject_args():
+    return dict(
+        initrd_inject=dict(type='str'),
+    )
+
+
+def get_install_args():
+    return dict(
+        install=dict(
+            type='dict',
+            options=dict(
+                os=dict(type='str', required=True),
+                kernel=dict(type='str'),
+                initrd=dict(type='str'),
+                kernel_args=dict(type='str'),
+                kernel_args_overwrite=dict(type='bool'),
+                bootdev=dict(type='str'),
+                no_install=dict(type='bool'),
+            ),
+        ),
+    )
+
+
+def get_unattended_args():
+    return dict(
+        unattended=dict(
+            type='dict',
+            options=dict(
+                profile=dict(type='str'),
+                admin_password_file=dict(type='str'),
+                user_login=dict(type='str'),
+                user_password_file=dict(type='str'),
+                product_key=dict(type='str', no_log=True),
+            ),
+        ),
+    )
+
+
+def get_cloud_init_args():
+    return dict(
+        cloud_init=dict(
+            type='dict',
+            options=dict(
+                root_password_generate=dict(type='bool'),
+                disable=dict(type='bool'),
+                root_password_file=dict(type='str'),
+                root_ssh_key=dict(type='str', no_log=True),
+                clouduser_ssh_key=dict(type='str', no_log=True),
+                network_config=dict(type='str'),
+                meta_data=dict(type='dict'),
+                user_data=dict(type='str'),
+            ),
+        ),
+    )
+
+
+def get_boot_args():
+    return dict(
+        boot=dict(type='str'),
+        boot_opts=dict(type='dict'),
+    )
+
+
+def get_idmap_args():
+    return dict(
+        idmap=dict(
+            type='dict',
+            options=dict(
+                uid=dict(
+                    type='dict',
+                    options=dict(
+                        start=dict(type='int'),
+                        target=dict(type='int'),
+                        count=dict(type='int'),
+                    ),
+                ),
+                gid=dict(
+                    type='dict',
+                    options=dict(
+                        start=dict(type='int'),
+                        target=dict(type='int'),
+                        count=dict(type='int'),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def get_osinfo_args():
+    return dict(
+        osinfo=dict(
+            type='dict',
+            options=dict(
+                name=dict(type='str', aliases=['short_id']),
+                id=dict(type='str'),
+                detect=dict(type='bool'),
+                require=dict(type='bool'),
+            ),
+        ),
+    )
+
+
+def get_disks_args():
+    return dict(
+        disks=dict(
+            type='list',
+            elements="dict",
+            options=dict(
+                path=dict(type='str'),
+                pool=dict(type='str'),
+                vol=dict(type='str'),
+                size=dict(type='int'),
+                sparse=dict(type='bool'),
+                format=dict(type='str'),
+                backing_store=dict(type='str'),
+                backing_format=dict(type='str'),
+                bus=dict(type='str'),
+                readonly=dict(type='bool'),
+                shareable=dict(type='bool'),
+                cache=dict(
+                    type='str',
+                    choices=[
+                        "none",
+                        "writethrough",
+                        "directsync",
+                        "unsafe",
+                        "writeback",
+                    ],
+                ),
+                serial=dict(type='str'),
+                snapshot=dict(
+                    type='str', choices=[
+                        'internal', 'external', 'no']),
+                rawio=dict(type='bool'),
+                sgio=dict(type='str', choices=['filtered', 'unfiltered']),
+                transient=dict(type='bool'),
+                transient_opts=dict(
+                    type='dict', options=dict(share_backing=dict(type='bool'))
+                ),
+                driver=dict(type='dict'),
+                source=dict(type='dict'),
+                target=dict(type='dict'),
+                address=dict(type='dict'),
+                boot=dict(type='dict'),
+                iotune=dict(type='dict'),
+                blockio=dict(type='dict'),
+                geometry=dict(type='dict'),
+            ),
+        ),
+    )
+
+
+def get_filesystems_args():
+    return dict(
+        filesystems=dict(
+            type='list',
+            elements="dict",
+            options=dict(
+                type=dict(
+                    type='str',
+                    choices=[
+                        'mount',
+                        'template',
+                        'file',
+                        'block',
+                        'ram',
+                        'bind'],
+                ),
+                accessmode=dict(
+                    type='str', choices=['passthrough', 'mapped', 'squash']
+                ),
+                source=dict(type='dict'),
+                target=dict(type='dict'),
+                fmode=dict(type='str'),
+                dmode=dict(type='str'),
+                multidevs=dict(
+                    type='str', choices=['default', 'remap', 'forbid', 'warn']
+                ),
+                readonly=dict(type='bool'),
+                space_hard_limit=dict(type='int'),
+                space_soft_limit=dict(type='int'),
+                driver=dict(type='dict'),
+                address=dict(type='dict'),
+                binary=dict(type='dict'),
+            ),
+        ),
+    )
+
+
+def get_networks_args():
+    return dict(
+        # Network options
+        networks=dict(
+            type='list',
+            elements="dict",
+            options=dict(
+                type=dict(type='str', choices=['direct']),
+                network=dict(type='str'),
+                bridge=dict(type='str'),
+                hostdev=dict(type='str'),
+                source=dict(type='dict'),
+                mac=dict(type='dict', options=dict(address=dict(type='str'))),
+                mtu=dict(type='dict'),
+                state=dict(type='dict'),
+                model=dict(type='dict', options=dict(type=dict(type='str'))),
+                driver=dict(type='dict'),
+                boot=dict(type='dict'),
+                filterref=dict(type='dict'),
+                rom=dict(type='dict'),
+                target=dict(type='dict'),
+                address=dict(type='dict'),
+                virtualport=dict(type='dict'),
+                trust_guest_rx_filters=dict(type='bool'),
+            ),
+        ),
+    )
+
+
+def get_graphics_args():
+    return dict(
+        graphics=dict(type='dict'),
+        graphics_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_virt_type_args():
+    return dict(
+        # Virtualization options
+        virt_type=dict(type='str'),
+    )
+
+
+def get_hvm_args():
+    return dict(
+        hvm=dict(type='bool'),
+    )
+
+
+def get_paravirt_args():
+    return dict(
+        paravirt=dict(type='bool'),
+    )
+
+
+def get_container_args():
+    return dict(
+        container=dict(type='bool'),
+    )
+
+
+def get_controller_args():
+    return dict(
+        controller=dict(type='dict'),
+        controller_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_input_args():
+    return dict(
+        input=dict(type='dict'),
+        input_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_hostdev_args():
+    return dict(
+        hostdev=dict(type='dict'),
+        host_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_sound_args():
+    return dict(
+        sound=dict(type='dict'),
+        sound_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_audio_args():
+    return dict(
+        audio=dict(type='dict'),
+        audio_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_watchdog_args():
+    return dict(
+        watchdog=dict(type='dict'),
+        watchdog_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_serial_args():
+    return dict(
+        serial=dict(type='dict'),
+        serial_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_parallel_args():
+    return dict(
+        parallel=dict(type='dict'),
+        parallel_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_channel_args():
+    return dict(
+        channel=dict(type='dict'),
+        channel_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_console_args():
+    return dict(
+        console=dict(type='dict'),
+        console_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_video_args():
+    return dict(
+        video=dict(type='dict'),
+        video_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_smartcard_args():
+    return dict(
+        smartcard=dict(type='dict'),
+        smartcard_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_redirdev_args():
+    return dict(
+        redirdev=dict(type='dict'),
+        redirected_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_memballoon_args():
+    return dict(
+        memballoon=dict(type='dict'),
+        memballoon_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_tpm_args():
+    return dict(
+        tpm=dict(type='dict'),
+        tpm_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_rng_args():
+    return dict(
+        rng=dict(type='dict'),
+        rng_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_panic_args():
+    return dict(
+        panic=dict(type='dict'),
+        panic_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_shmem_args():
+    return dict(
+        shmem=dict(type='dict'),
+        shmem_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_vsock_args():
+    return dict(
+        vsock=dict(type='dict'),
+        vsock_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_iommu_args():
+    return dict(
+        iommu=dict(type='dict'),
+        iommu_devices=dict(type='list', elements="dict"),
+    )
+
+
+def get_autostart_args():
+    return dict(
+        # Miscellaneous options
+        autostart=dict(type='bool'),
+    )
+
+
+def get_transient_args():
+    return dict(
+        transient=dict(type='bool'),
+    )
+
+
+def get_destroy_on_exit_args():
+    return dict(
+        destroy_on_exit=dict(type='bool'),
+    )
+
+
+def get_noreboot_args():
+    return dict(
+        noreboot=dict(type='bool'),
+    )

--- a/plugins/modules/virt_cloud_instance.py
+++ b/plugins/modules/virt_cloud_instance.py
@@ -1,0 +1,765 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2025, Joey Zhang <thinkdoggie@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = """
+---
+module: virt_cloud_instance
+version_added: 2.1.0
+author: "Joey Zhang (@thinkdoggie)"
+short_description: Provision new virtual machines from cloud images via libvirt
+description:
+  - Create and customize virtual machines using pre-built cloud images with cloud-init support.
+  - Cloud images can be retrieved from local files and remote URLs.
+  - Supports automatic conversion and resizing of disk images.
+options:
+  name:
+    type: str
+    description:
+      - Name of the new guest virtual machine instance.
+    required: true
+  state:
+    choices: [ present, absent ]
+    type: str
+    description:
+      - If set to V(present), create the VM if it does not exist.
+    default: present
+  recreate:
+    type: bool
+    description:
+      - Use with present to force the re-creation of an existing VM.
+    default: false
+  base_image:
+    type: str
+    description:
+      - Path or URL to the cloud image.
+      - Can be a local file path or a remote URL (http, https, ftp).
+      - The image will be automatically downloaded if a URL is provided.
+    required: true
+  image_cache_dir:
+    type: path
+    description:
+      - Directory where downloaded cloud images will be cached.
+      - Only used when O(base_image) is a URL.
+      - If not specified, the base image will be downloaded to the temporary directory and not be cached.
+  force_pull:
+    type: bool
+    description:
+      - Force pull of the cloud image even if it already exists in the cache.
+      - Only used when O(base_image) is a URL.
+      - Useful for updating cached images to their latest versions.
+    default: false
+  image_checksum:
+    type: str
+    description:
+      - If specified, the digest of the downloaded image will be calculated to verify the integrity of the downloaded image.
+      - "Format: <algorithm>:<checksum|url>, e.g. I(sha256:D98291AC[...]B6DC7B97), I(sha256:http://example.com/path/sha256sum.txt)."
+      - Only used when O(base_image) is a URL.
+      - If you worry about portability, only the sha1 algorithm is available on all platforms and python versions.
+  url_timeout:
+    type: int
+    default: 60
+    description:
+      - The timeout in seconds for downloading the base image from a URL.
+      - Only used when O(base_image) is a URL.
+  url_username:
+    type: str
+    description:
+      - The username for HTTP basic authentication.
+      - Only used when O(base_image) is a URL.
+  url_password:
+    type: str
+    description:
+      - The password for HTTP basic authentication.
+      - Only used when O(base_image) is a URL.
+  wait_for_cloud_init_reboot:
+    type: bool
+    default: true
+    description:
+      - If set to V(true), wait for cloud-init to trigger a reboot and for the VM to come back online.
+      - This requires that your cloud-init user-data includes a reboot action, or I(cloud_init_auto_reboot=true).
+      - Only applicable when O(cloud_init) configuration is provided.
+  cloud_init_auto_reboot:
+    type: bool
+    default: true
+    description:
+      - When I(wait_for_cloud_init_reboot=true), automatically inject a reboot instruction into the cloud-init user-data.
+      - If set to V(false), the reboot instructions should be included in the cloud-init user-data manually.
+      - Only applies when I(wait_for_cloud_init_reboot=true).
+  cloud_init_reboot_timeout:
+    type: int
+    default: 600
+    description:
+      - Maximum time in seconds to wait for the cloud-init reboot cycle to complete.
+      - The timeout is checked at minute intervals, so the actual timeout may be up to 60 seconds longer.
+      - Only applies when I(wait_for_cloud_init_reboot=true).
+      - If the timeout is exceeded, the task will fail.
+extends_documentation_fragment:
+    - community.libvirt.virt.options_uri
+    - community.libvirt.virt_install.options_cloud_init
+    - community.libvirt.virt_install.options_memory
+    - community.libvirt.virt_install.options_memorybacking
+    - community.libvirt.virt_install.options_arch
+    - community.libvirt.virt_install.options_machine
+    - community.libvirt.virt_install.options_metadata
+    - community.libvirt.virt_install.options_events
+    - community.libvirt.virt_install.options_resource
+    - community.libvirt.virt_install.options_sysinfo
+    - community.libvirt.virt_install.options_qemu_commandline
+    - community.libvirt.virt_install.options_vcpus
+    - community.libvirt.virt_install.options_numatune
+    - community.libvirt.virt_install.options_memtune
+    - community.libvirt.virt_install.options_blkiotune
+    - community.libvirt.virt_install.options_cpu
+    - community.libvirt.virt_install.options_cputune
+    - community.libvirt.virt_install.options_security
+    - community.libvirt.virt_install.options_keywrap
+    - community.libvirt.virt_install.options_iothreads
+    - community.libvirt.virt_install.options_features
+    - community.libvirt.virt_install.options_clock
+    - community.libvirt.virt_install.options_pm
+    - community.libvirt.virt_install.options_launch_security
+    - community.libvirt.virt_install.options_osinfo
+    - community.libvirt.virt_install.options_disks
+    - community.libvirt.virt_install.options_filesystems
+    - community.libvirt.virt_install.options_networks
+    - community.libvirt.virt_install.options_graphics_devices
+    - community.libvirt.virt_install.options_virt_type
+    - community.libvirt.virt_install.options_hvm
+    - community.libvirt.virt_install.options_paravirt
+    - community.libvirt.virt_install.options_controller_devices
+    - community.libvirt.virt_install.options_input_devices
+    - community.libvirt.virt_install.options_host_devices
+    - community.libvirt.virt_install.options_sound_devices
+    - community.libvirt.virt_install.options_audio_devices
+    - community.libvirt.virt_install.options_watchdog_devices
+    - community.libvirt.virt_install.options_serial_devices
+    - community.libvirt.virt_install.options_parallel_devices
+    - community.libvirt.virt_install.options_channel_devices
+    - community.libvirt.virt_install.options_console_devices
+    - community.libvirt.virt_install.options_video_devices
+    - community.libvirt.virt_install.options_smartcard_devices
+    - community.libvirt.virt_install.options_redirected_devices
+    - community.libvirt.virt_install.options_memballoon_devices
+    - community.libvirt.virt_install.options_tpm_devices
+    - community.libvirt.virt_install.options_rng_devices
+    - community.libvirt.virt_install.options_panic_devices
+    - community.libvirt.virt_install.options_shmem_devices
+    - community.libvirt.virt_install.options_vsock_devices
+    - community.libvirt.virt_install.options_iommu_devices
+    - community.libvirt.virt_install.options_autostart
+    - community.libvirt.requirements
+attributes:
+    check_mode:
+        description: Supports check_mode.
+        support: full
+requirements:
+    - "virt-install"
+    - "qemu-img"
+notes:
+    - The C(virt-install) command is provided by different packages on different distributions.
+    - On Debian/Ubuntu, install the C(virtinst) package.
+    - On RHEL/CentOS/Fedora and openSUSE, install the C(virt-install) package.
+    - When O(wait_for_cloud_init_reboot=true), ensure your cloud-init user-data includes appropriate reboot commands or set O(cloud_init_auto_reboot=true).
+    - The O(cloud_init_auto_reboot) parameter automatically injects I(power_state.mode=reboot) at the end of user-data when enabled.
+    - The module waits through the complete cloud-init process including any reboots specified in the user-data.
+    - Use O(cloud_init_reboot_timeout) to control the maximum wait time for complex cloud-init configurations.
+seealso:
+  - module: community.libvirt.virt_install
+    description: More general VM installation module.
+  - name: virt-install Man Page
+    description: Ubuntu manpage of virt-install tool.
+    link: https://manpages.ubuntu.com/manpages/focal/man1/virt-install.1.html
+"""
+
+
+EXAMPLES = """
+# Basic example: Create a VM from a local cloud image
+- name: Create Ubuntu VM from local cloud image
+  community.libvirt.virt_cloud_instance:
+    name: ubuntu-vm-01
+    base_image: /srv/images/ubuntu-22.04-server-cloudimg-amd64.img
+    disks:
+      - path: /var/lib/libvirt/images/ubuntu-vm-01.qcow2
+        size: 20
+        format: qcow2
+    memory: 2048
+    vcpus: 2
+    networks:
+      - network: default
+
+# Download cloud image from URL with checksum validation
+- name: Create VM from remote Ubuntu cloud image
+  community.libvirt.virt_cloud_instance:
+    name: ubuntu-vm-02
+    base_image: https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img
+    image_cache_dir: /srv/cloud-images
+    image_checksum: sha256:https://cloud-images.ubuntu.com/releases/22.04/release/SHA256SUMS
+    disks:
+      - path: /var/lib/libvirt/images/ubuntu-vm-02.qcow2
+        size: 30
+        format: qcow2
+    memory: 4096
+    vcpus: 4
+    networks:
+      - network: default
+
+# Advanced example with cloud-init configuration
+- name: Create VM with cloud-init user data
+  community.libvirt.virt_cloud_instance:
+    name: web-server-01
+    base_image: /srv/images/ubuntu-22.04-server-cloudimg-amd64.img
+    disks:
+      - path: /var/lib/libvirt/images/web-server-01.qcow2
+        size: 50
+        format: qcow2
+    memory: 8192
+    vcpus: 4
+    networks:
+      - network: default
+        mac: 52:54:00:12:34:56
+    cloud_init:
+      user_data: |
+        #cloud-config
+        users:
+          - name: ansible
+            groups: sudo
+            shell: /bin/bash
+            sudo: 'ALL=(ALL) NOPASSWD:ALL'
+            ssh_authorized_keys:
+              - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAB... user@host
+        packages:
+          - nginx
+          - htop
+          - vim
+        runcmd:
+          - systemctl enable nginx
+          - systemctl start nginx
+      meta_data:
+        instance-id: web-server-01
+        local-hostname: web-server-01
+"""
+
+RETURN = r"""
+base_image_path:
+    description:
+        - Path to the base cloud image file.
+        - This is the local path where the image was downloaded to (if URL was provided) or the original local path.
+    type: str
+    returned: success
+    sample: "/srv/cloud-images/ubuntu-20.04-server-cloudimg-amd64.img"
+"""
+
+
+import os
+import re
+from urllib.parse import urlparse
+from ansible_collections.community.libvirt.plugins.module_utils import virt_install as virtinst_util
+from ansible_collections.community.libvirt.plugins.module_utils.virt_install import (
+    LibvirtWrapper, VirtInstallTool
+)
+from ansible_collections.community.libvirt.plugins.module_utils.libvirt import (
+    HAS_VIRT, HAS_XML, VMNotFound, VIRT_SUCCESS
+)
+from ansible_collections.community.libvirt.plugins.module_utils.qemu import QemuImgTool
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_file, fetch_url
+
+
+class BaseImageOperator(object):
+    def __init__(self, module, base_image, image_cache_dir=None, image_checksum=None):
+        self.module = module
+        self.base_image = base_image
+        self.image_cache_dir = image_cache_dir
+        self.image_checksum = image_checksum
+        self.base_image_path = None
+        self.system_disk_path = None
+
+    def fetch_image(self, force_pull, timeout=None):
+        """
+        Fetch cloud image from URL or use local file.
+
+        This operation may download and create files, so it respects check_mode.
+        In check_mode, image download is skipped but local files are still validated.
+        """
+        parsed_url = urlparse(self.base_image)
+
+        if parsed_url.scheme not in ('http', 'https', 'ftp'):
+            # The base image is a local file path
+            if not os.path.exists(self.base_image):
+                self.module.fail_json(
+                    msg="Base image file does not exist: %s" % self.base_image)
+            self.base_image_path = self.base_image
+            return self.base_image_path
+
+        filename = os.path.basename(parsed_url.path)
+        if not filename:
+            self.module.fail_json(
+                msg="Failed to determine filename from base image URL: %s" % self.base_image)
+
+        if self.image_cache_dir:
+            image_path = os.path.join(self.image_cache_dir, filename)
+            if os.path.exists(image_path) and not force_pull:
+                self.base_image_path = image_path
+                return self.base_image_path
+        else:
+            image_path = os.path.join(self.module.tmpdir, filename)
+
+        # Check if we're in check mode
+        if self.module.check_mode:
+            # In check mode, don't download but set the expected path
+            self.base_image_path = image_path
+            return self.base_image_path
+
+        temp_file = fetch_file(self.module, self.base_image, timeout=timeout)
+        self.module.atomic_move(temp_file, image_path)
+
+        self.base_image_path = image_path
+        return self.base_image_path
+
+    def _resolve_system_disk(self, disk_param):
+        # TODO: Support specifying the system disk as a pool volume
+
+        if not disk_param.get('path'):
+            raise ValueError(
+                "The first disk must have a path to import the cloud image")
+
+        self.system_disk_path = disk_param.get('path')
+
+        return disk_param
+
+    def validate_checksum(self):
+        """
+        Validate the checksum of the base image.
+
+        This operation is read-only but depends on the actual file.
+        In check_mode, validation is skipped if the file doesn't exist locally.
+        """
+        if not self.image_checksum:
+            return True
+
+        # In check_mode, skip validation if file doesn't exist
+        # (e.g., when base_image is a URL that wasn't downloaded)
+        if self.module.check_mode and (not self.base_image_path or not os.path.exists(self.base_image_path)):
+            return True  # Assume validation would pass in check_mode
+
+        if not self.base_image_path or not os.path.exists(self.base_image_path):
+            self.module.fail_json(
+                msg="Base image path not found for checksum validation")
+
+        # Parse checksum format: <algorithm>:<checksum|url>
+        try:
+            algorithm, checksum_expr = self.image_checksum.split(':', 1)
+        except ValueError:
+            self.module.fail_json(
+                msg="The image_checksum parameter has to be in format <algorithm>:<checksum>")
+
+        # Check if checksum is a URL
+        parsed_url = urlparse(checksum_expr)
+        if parsed_url.scheme in ('http', 'https', 'ftp'):
+            checksum = self._fetch_checksum_from_url(checksum_expr, algorithm)
+        else:
+            checksum = checksum_expr
+
+        # Remove any non-alphanumeric characters and convert to lowercase
+        checksum = re.sub(r'\W+', '', checksum).lower()
+
+        # Ensure the checksum portion is a hexdigest
+        try:
+            int(checksum, 16)
+        except ValueError:
+            self.module.fail_json(msg='The checksum format is invalid')
+
+        # Calculate the actual checksum of the file
+        actual_checksum = None
+        try:
+            actual_checksum = self.module.digest_from_file(
+                self.base_image_path, algorithm)
+        except ValueError as e:
+            self.module.fail_json(
+                msg="Failed to calculate the actual checksum of the file: %s" % str(e))
+
+        # Compare checksums
+        return checksum == actual_checksum
+
+    def _fetch_checksum_from_url(self, checksum_url, algorithm):
+        # Download checksum file
+        response, info = fetch_url(self.module, checksum_url, timeout=60)
+        if response is None:
+            self.module.fail_json(msg="Failed to download checksum from %s: %s" % (
+                checksum_url, info.get('msg', 'Unknown error')))
+
+        try:
+            checksum_content = response.read().decode('utf-8')
+        finally:
+            response.close()
+
+        lines = [line.rstrip('\n') for line in checksum_content.splitlines()]
+        checksum_map = []
+
+        # Get the filename from the base image URL for matching
+        filename = os.path.basename(urlparse(self.base_image).path)
+
+        if len(lines) == 1 and len(lines[0].split()) == 1:
+            # Only a single line with a single string - treat it as a checksum only file
+            checksum_map.append((lines[0], filename))
+        else:
+            # The file is in the format of "checksum filename"
+            for line in lines:
+                # Split by one whitespace to keep the leading type char ' ' (whitespace) for text and '*' for binary
+                parts = line.split(" ", 1)
+                if len(parts) == 2:
+                    # Remove the leading type char if present
+                    if parts[1].startswith((" ", "*")):
+                        parts[1] = parts[1][1:]
+
+                    # Append checksum and path without potential leading './'
+                    checksum_map.append((parts[0], parts[1].lstrip("./")))
+
+        # Look through each line in the checksum file for a hash corresponding to
+        # the filename in the url, returning the first hash that is found.
+        for cksum in (s for (s, f) in checksum_map if f == filename):
+            return cksum
+
+        self.module.fail_json(
+            msg="Unable to find a checksum for file '%s' in '%s'" % (filename, checksum_url))
+
+    def build_system_disk(self, disk_param):
+        """
+        Build system disk from base image.
+
+        This operation creates and modifies disk files, so it respects check_mode.
+        In check_mode, validation is performed but no files are created or modified.
+        """
+        system_disk = self._resolve_system_disk(disk_param)
+        disk_path = self.system_disk_path
+        base_image_path = self.base_image_path
+
+        if os.path.exists(disk_path):
+            self.module.fail_json(
+                msg="The system disk file already exists: %s" % disk_path)
+
+        qemuImgTool = QemuImgTool(self.module)
+
+        # Get base image info - this is read-only and should work in check_mode
+        # However, if we're in check_mode and the base image doesn't exist locally,
+        # we may need to skip this check
+        if self.module.check_mode and not os.path.exists(base_image_path):
+            # In check mode with non-existent base image, create mock info for validation
+            base_image_format = "qcow2"  # Assume common format
+            base_image_raw_size = 1 * 1024 * 1024 * 1024  # Assume 1GB minimum
+        else:
+            rc, image_info, stderr = qemuImgTool.info(base_image_path)
+            if rc != 0:
+                self.module.fail_json(
+                    msg="Failed to get base image info: %s" % stderr)
+            base_image_format = image_info.get('format')
+            base_image_raw_size = image_info.get('virtual-size')
+
+        system_disk_format = system_disk.get('format', "qcow2")
+        system_disk_size = system_disk.get('size')
+        if not base_image_format:
+            self.module.fail_json(
+                msg="No valid format found for the base image: %s" % base_image_path)
+        if not system_disk_size or not isinstance(system_disk_size, int):
+            self.module.fail_json(
+                msg="The system disk size must be an integer")
+        system_disk_raw_size = system_disk_size * 1024 * 1024 * 1024
+        if system_disk_raw_size < base_image_raw_size:
+            self.module.fail_json(msg="The system disk size is too small to import the base image: %s < %s" % (
+                system_disk_raw_size, base_image_raw_size))
+
+        # Check if we're in check mode
+        if self.module.check_mode:
+            # In check mode, don't create files but return the disk configuration
+            return system_disk
+
+        if base_image_format != system_disk_format:
+            rc, stdout, stderr = qemuImgTool.convert(
+                base_image_path, disk_path, source_format=base_image_format, output_format=system_disk_format)
+            if rc != 0:
+                self.module.fail_json(
+                    msg="Failed to convert base image to system disk: %s" % stderr)
+        else:
+            self.module.preserved_copy(base_image_path, disk_path)
+
+        rc, stdout, stderr = qemuImgTool.resize(
+            disk_path, "%dG" % system_disk_size)
+        if rc != 0:
+            self.module.fail_json(
+                msg="Failed to resize system disk: %s" % stderr)
+
+        for key in ['format', 'size']:
+            if key in system_disk:
+                del system_disk[key]
+
+        return system_disk
+
+
+def validate_disks(disks):
+    if not isinstance(disks, list) \
+            or len(disks) < 1:
+        raise ValueError("At least one disk is required")
+
+    system_disk = disks[0]
+
+    if not (system_disk.get('path') or system_disk.get('pool')):
+        raise ValueError(
+            "The first disk must have either 'path' or 'pool' to import the cloud image")
+
+    if not system_disk.get('size'):
+        raise ValueError("The first disk must have a size")
+
+
+def update_virtinst_params(virtInstall, system_disk, extra_user_data=None):
+    disks = virtInstall.params.get('disks')
+
+    if not isinstance(disks, list) \
+            or len(disks) < 1:
+        raise ValueError("At least one disk is required")
+
+    virtInstall.params['disks'][0] = system_disk
+    virtInstall.params['import'] = True
+
+    if extra_user_data:
+        if virtInstall.params.get('cloud_init') is None:
+            virtInstall.params['cloud_init'] = {}
+
+        orignal_user_data = virtInstall.params['cloud_init'].get('user_data', "")
+        modified_user_data = orignal_user_data + extra_user_data
+        virtInstall.params['cloud_init']['user_data'] = modified_user_data
+
+
+def get_autoreboot_user_data():
+    return """
+# appended by virt_cloud_instance module
+power_state:
+  delay: 1
+  mode: reboot
+  message: Rebooting for cloud instance provisioning
+"""
+
+
+def core(module):
+    state = module.params.get('state')
+    name = module.params.get('name')
+    recreate = module.params.get('recreate', False)
+    base_image = module.params.get('base_image')
+    image_cache_dir = module.params.get('image_cache_dir')
+    force_pull = module.params.get('force_pull', False)
+    disks = module.params.get('disks', [])
+    image_checksum = module.params.get('image_checksum')
+    url_timeout = module.params.get('url_timeout')
+    wait_for_cloud_init_reboot = module.params.get('wait_for_cloud_init_reboot', True)
+    cloud_init_auto_reboot = module.params.get('cloud_init_auto_reboot', True)
+    cloud_init_reboot_timeout = module.params.get('cloud_init_reboot_timeout')
+
+    validate_disks(disks)
+
+    result = dict(
+        changed=False,
+        original_message="",
+        message="",
+        base_image_path="",
+    )
+
+    virtConn = LibvirtWrapper(module)
+    virtInstall = VirtInstallTool(module)
+
+    if not name:
+        module.fail_json(msg="virtual machine name is missing")
+
+    if not base_image:
+        module.fail_json(msg="base_image parameter is required")
+
+    vm_exists = False
+    try:
+        vm = virtConn.find_vm(name)
+        vm_exists = True
+    except VMNotFound:
+        vm_exists = False
+
+    if state == 'present':
+        if vm_exists and not recreate:
+            result['message'] = "virtual machine '%s' already exists" % name
+            return VIRT_SUCCESS, result
+        elif vm_exists and recreate:
+            # In check_mode, skip VM destruction but continue with validation
+            if not module.check_mode:
+                if vm.isActive():
+                    virtConn.destroy(name)
+                virtConn.undefine(name)
+
+        # Create image operator only when we need to process the image
+        image_operator = BaseImageOperator(module, base_image,
+                                           image_cache_dir=image_cache_dir,
+                                           image_checksum=image_checksum)
+        image_operator.fetch_image(force_pull, timeout=url_timeout)
+        if not image_operator.validate_checksum():
+            module.fail_json(
+                msg="The checksum of the base image does not match the expected value")
+        system_disk = image_operator.build_system_disk(disks[0])
+
+        # Add base_image_path to result
+        result['base_image_path'] = image_operator.base_image_path
+
+        extra_user_data = None
+        if wait_for_cloud_init_reboot and cloud_init_auto_reboot:
+            extra_user_data = get_autoreboot_user_data()
+
+        wait_timeout = None
+        if wait_for_cloud_init_reboot:
+            wait_timeout = cloud_init_reboot_timeout
+
+        # run virt-install to create new vm
+        update_virtinst_params(virtInstall, system_disk, extra_user_data)
+        changed, rc, extra_res = virtInstall.execute(dryrun=module.check_mode, wait_timeout=wait_timeout)
+        # result['virt_install_command'] = ' '.join(virtInstall.command_argv)
+        result['changed'] = changed
+        result.update(extra_res)
+
+        if wait_for_cloud_init_reboot and rc == 0:
+            virtConn.create(name)
+
+        return rc, result
+    elif state == 'absent':
+        if not vm_exists:
+            result['message'] = "virtual machine '%s' is already absent" % name
+            return VIRT_SUCCESS, result
+
+        if not module.check_mode:
+            if vm.isActive():
+                virtConn.destroy(name)
+            virtConn.undefine(name)
+
+        result["changed"] = True
+        return VIRT_SUCCESS, result
+
+    module.fail_json(msg="unsupported state '%s'" % state)
+
+
+def main():
+    """Main module entry point"""
+
+    # Define argument specification
+    argument_spec = dict(
+        # Connection options
+        uri=dict(type='str', default="qemu:///system"),
+        # Basic VM options
+        name=dict(type='str', required=True),
+        state=dict(
+            type='str',
+            choices=['present', 'absent'],
+            default='present'),
+        recreate=dict(type='bool', default=False),
+        # Cloud image specific options
+        base_image=dict(type='str', required=True),
+        image_cache_dir=dict(type='path'),
+        force_pull=dict(type='bool', default=False),
+        image_checksum=dict(type='str'),
+        url_timeout=dict(type='int', default=60),
+        url_username=dict(type='str'),
+        url_password=dict(type='str', no_log=True),
+        wait_for_cloud_init_reboot=dict(type='bool', default=True),
+        cloud_init_auto_reboot=dict(type='bool', default=True),
+        cloud_init_reboot_timeout=dict(type='int', default=600),
+    )
+
+    # Cloud-init options
+    argument_spec.update(virtinst_util.get_cloud_init_args())
+    # Hardware configuration
+    argument_spec.update(virtinst_util.get_memory_args())
+    argument_spec.update(virtinst_util.get_memorybacking_args())
+    argument_spec.update(virtinst_util.get_arch_args())
+    argument_spec.update(virtinst_util.get_machine_args())
+    argument_spec.update(virtinst_util.get_metadata_args())
+    argument_spec.update(virtinst_util.get_events_args())
+    argument_spec.update(virtinst_util.get_resource_args())
+    argument_spec.update(virtinst_util.get_sysinfo_args())
+    argument_spec.update(virtinst_util.get_qmeu_commandline_args())
+    # CPU configuration
+    argument_spec.update(virtinst_util.get_vcpu_args())
+    argument_spec.update(virtinst_util.get_numatune_args())
+    argument_spec.update(virtinst_util.get_memtune_args())
+    argument_spec.update(virtinst_util.get_blkiotune_args())
+    argument_spec.update(virtinst_util.get_cpu_args())
+    argument_spec.update(virtinst_util.get_cputune_args())
+    argument_spec.update(virtinst_util.get_security_args())
+    argument_spec.update(virtinst_util.get_keywrap_args())
+    argument_spec.update(virtinst_util.get_iothreads_args())
+    argument_spec.update(virtinst_util.get_features_args())
+    argument_spec.update(virtinst_util.get_clock_args())
+    argument_spec.update(virtinst_util.get_pm_args())
+    argument_spec.update(virtinst_util.get_launch_security_args())
+    # Guest OS options
+    argument_spec.update(virtinst_util.get_osinfo_args())
+    # Storage options
+    argument_spec.update(virtinst_util.get_disks_args())
+    argument_spec.update(virtinst_util.get_filesystems_args())
+    # Network options
+    argument_spec.update(virtinst_util.get_networks_args())
+    # Graphics options
+    argument_spec.update(virtinst_util.get_graphics_args())
+    # Virtualization options
+    argument_spec.update(virtinst_util.get_virt_type_args())
+    argument_spec.update(virtinst_util.get_hvm_args())
+    argument_spec.update(virtinst_util.get_paravirt_args())
+    # Device options
+    argument_spec.update(virtinst_util.get_controller_args())
+    argument_spec.update(virtinst_util.get_input_args())
+    argument_spec.update(virtinst_util.get_hostdev_args())
+    argument_spec.update(virtinst_util.get_sound_args())
+    argument_spec.update(virtinst_util.get_audio_args())
+    argument_spec.update(virtinst_util.get_watchdog_args())
+    argument_spec.update(virtinst_util.get_serial_args())
+    argument_spec.update(virtinst_util.get_parallel_args())
+    argument_spec.update(virtinst_util.get_channel_args())
+    argument_spec.update(virtinst_util.get_console_args())
+    argument_spec.update(virtinst_util.get_video_args())
+    argument_spec.update(virtinst_util.get_smartcard_args())
+    argument_spec.update(virtinst_util.get_redirdev_args())
+    argument_spec.update(virtinst_util.get_memballoon_args())
+    argument_spec.update(virtinst_util.get_tpm_args())
+    argument_spec.update(virtinst_util.get_rng_args())
+    argument_spec.update(virtinst_util.get_panic_args())
+    argument_spec.update(virtinst_util.get_shmem_args())
+    argument_spec.update(virtinst_util.get_vsock_args())
+    argument_spec.update(virtinst_util.get_iommu_args())
+    # Miscellaneous options
+    argument_spec.update(virtinst_util.get_autostart_args())
+
+    # Create module
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True)
+
+    if not HAS_VIRT:
+        module.fail_json(
+            msg="The `libvirt` module is not importable. Check the requirements.")
+
+    if not HAS_XML:
+        module.fail_json(
+            msg='The `lxml` module is not importable. Check the requirements.'
+        )
+
+    rc = VIRT_SUCCESS
+    try:
+        rc, result = core(module)
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+    if rc != 0:  # something went wrong emit the msg
+        module.fail_json(rc=rc, msg=result)
+    else:
+        module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/module_utils/test_qemu.py
+++ b/tests/unit/module_utils/test_qemu.py
@@ -1,0 +1,780 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import json
+
+from ansible_collections.community.libvirt.tests.unit.compat import mock
+from ansible_collections.community.libvirt.plugins.module_utils.qemu import QemuImgTool
+
+
+class TestQemuImgToolInit(unittest.TestCase):
+    """Test QemuImgTool initialization"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+
+    def test_init_default_command(self):
+        """Test initialization with default qemu-img command"""
+        tool = QemuImgTool(self.mock_module)
+
+        self.assertEqual(tool.module, self.mock_module)
+        self.assertEqual(tool.warnings, [])
+        self.assertEqual(tool.command_argv, ['qemu-img'])
+
+    def test_init_custom_command(self):
+        """Test initialization with custom command"""
+        custom_cmd = '/usr/local/bin/qemu-img'
+        tool = QemuImgTool(self.mock_module, qemu_img_path=custom_cmd)
+
+        self.assertEqual(tool.module, self.mock_module)
+        self.assertEqual(tool.warnings, [])
+        self.assertEqual(tool.command_argv, [custom_cmd])
+
+    def test_init_none_command(self):
+        """Test initialization with None command (should use default)"""
+        tool = QemuImgTool(self.mock_module, qemu_img_path=None)
+
+        self.assertEqual(tool.command_argv, ['qemu-img'])
+
+
+class TestQemuImgToolHelperMethods(unittest.TestCase):
+    """Test QemuImgTool helper methods"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+        self.tool = QemuImgTool(self.mock_module)
+
+    def test_add_flag(self):
+        """Test adding a flag to command line"""
+        self.tool._add_flag('--verbose')
+        self.assertEqual(self.tool.command_argv, ['qemu-img', '--verbose'])
+
+    def test_add_option_with_value(self):
+        """Test adding an option with value"""
+        self.tool._add_option('-f', 'qcow2')
+        self.assertEqual(self.tool.command_argv, ['qemu-img', '-f', 'qcow2'])
+
+    def test_add_option_with_none_value(self):
+        """Test adding an option with None value (should be ignored)"""
+        self.tool._add_option('-f', None)
+        self.assertEqual(self.tool.command_argv, ['qemu-img'])
+
+    def test_add_option_with_numeric_value(self):
+        """Test adding an option with numeric value"""
+        self.tool._add_option('-m', 4)
+        self.assertEqual(self.tool.command_argv, ['qemu-img', '-m', '4'])
+
+    def test_add_option_list_empty(self):
+        """Test adding option list with empty list"""
+        self.tool._add_option_list('-o', [])
+        self.assertEqual(self.tool.command_argv, ['qemu-img'])
+
+    def test_add_option_list_with_values(self):
+        """Test adding option list with values"""
+        self.tool._add_option_list(
+            '-o', ['preallocation=metadata', 'lazy_refcounts=on'])
+        expected = ['qemu-img', '-o', 'preallocation=metadata',
+                    '-o', 'lazy_refcounts=on']
+        self.assertEqual(self.tool.command_argv, expected)
+
+    def test_add_option_list_with_none_values(self):
+        """Test adding option list with some None values"""
+        self.tool._add_option_list(
+            '-o', ['preallocation=metadata', None, 'lazy_refcounts=on'])
+        expected = ['qemu-img', '-o', 'preallocation=metadata',
+                    '-o', 'lazy_refcounts=on']
+        self.assertEqual(self.tool.command_argv, expected)
+
+
+class TestQemuImgToolConvert(unittest.TestCase):
+    """Test QemuImgTool convert method"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+        self.tool = QemuImgTool(self.mock_module)
+
+    def test_convert_basic(self):
+        """Test basic convert operation"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.convert('input.qcow2', 'output.qcow2')
+
+        expected_cmd = ['qemu-img', 'convert', 'input.qcow2', 'output.qcow2']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_convert_with_formats(self):
+        """Test convert with source and output formats"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.convert(
+            'input.img', 'output.qcow2',
+            source_format='raw', output_format='qcow2'
+        )
+
+        expected_cmd = ['qemu-img', 'convert', '-f', 'raw',
+                        '-O', 'qcow2', 'input.img', 'output.qcow2']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_convert_with_compression(self):
+        """Test convert with compression enabled"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.convert(
+            'input.qcow2', 'output.qcow2',
+            compressed=True
+        )
+
+        expected_cmd = ['qemu-img', 'convert',
+                        '-c', 'input.qcow2', 'output.qcow2']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_convert_with_sparse_size(self):
+        """Test convert with sparse size option"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.convert(
+            'input.qcow2', 'output.qcow2',
+            sparse_size='4k'
+        )
+
+        expected_cmd = ['qemu-img', 'convert', '-S',
+                        '4k', 'input.qcow2', 'output.qcow2']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_convert_with_num_coroutines(self):
+        """Test convert with number of coroutines"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.convert(
+            'input.qcow2', 'output.qcow2',
+            num_coroutines=4
+        )
+
+        expected_cmd = ['qemu-img', 'convert', '-m',
+                        '4', 'input.qcow2', 'output.qcow2']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_convert_with_all_options(self):
+        """Test convert with all options enabled"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.convert(
+            'input.raw', 'output.qcow2',
+            source_format='raw',
+            output_format='qcow2',
+            compressed=True,
+            sparse_size='64k',
+            num_coroutines=8
+        )
+
+        expected_cmd = [
+            'qemu-img', 'convert',
+            '-f', 'raw',
+            '-O', 'qcow2',
+            '-c',
+            '-S', '64k',
+            '-m', '8',
+            'input.raw', 'output.qcow2'
+        ]
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_convert_failure(self):
+        """Test convert operation failure"""
+        self.mock_module.run_command.return_value = (
+            1, '', 'qemu-img: error: Could not open input file')
+
+        rc, stdout, stderr = self.tool.convert(
+            'nonexistent.qcow2', 'output.qcow2')
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(stderr, 'qemu-img: error: Could not open input file')
+
+    def test_convert_with_spaces_in_filenames(self):
+        """Test convert with filenames containing spaces"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.convert(
+            'input file.qcow2', 'output file.qcow2')
+
+        expected_cmd = ['qemu-img', 'convert',
+                        'input file.qcow2', 'output file.qcow2']
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+
+class TestQemuImgToolInfo(unittest.TestCase):
+    """Test QemuImgTool info method"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+        self.tool = QemuImgTool(self.mock_module)
+
+    def test_info_basic(self):
+        """Test basic info operation"""
+        info_output = {
+            "virtual-size": 1073741824,
+            "filename": "test.qcow2",
+            "cluster-size": 65536,
+            "format": "qcow2",
+            "actual-size": 262144,
+            "format-specific": {
+                "type": "qcow2",
+                "data": {
+                    "compat": "1.1",
+                    "lazy-refcounts": False,
+                    "refcount-bits": 16,
+                    "corrupt": False
+                }
+            }
+        }
+        self.mock_module.run_command.return_value = (
+            0, json.dumps(info_output), '')
+
+        rc, parsed_output, stderr = self.tool.info('test.qcow2')
+
+        expected_cmd = ['qemu-img', 'info', '--output', 'json', 'test.qcow2']
+        self.assertEqual(rc, 0)
+        self.assertEqual(parsed_output, info_output)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_info_with_source_format(self):
+        """Test info with source format specified"""
+        self.mock_module.run_command.return_value = (0, '{}', '')
+
+        rc, parsed_output, stderr = self.tool.info(
+            'test.img', source_format='raw')
+
+        expected_cmd = ['qemu-img', 'info', '-f',
+                        'raw', '--output', 'json', 'test.img']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_info_with_backing_chain(self):
+        """Test info with backing chain option"""
+        self.mock_module.run_command.return_value = (0, '{}', '')
+
+        rc, parsed_output, stderr = self.tool.info(
+            'test.qcow2', backing_chain=True)
+
+        expected_cmd = ['qemu-img', 'info', '--backing-chain',
+                        '--output', 'json', 'test.qcow2']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_info_with_all_options(self):
+        """Test info with all options"""
+        self.mock_module.run_command.return_value = (0, '{}', '')
+
+        rc, parsed_output, stderr = self.tool.info(
+            'test.qcow2',
+            source_format='qcow2',
+            backing_chain=True
+        )
+
+        expected_cmd = [
+            'qemu-img', 'info',
+            '-f', 'qcow2',
+            '--backing-chain',
+            '--output', 'json',
+            'test.qcow2'
+        ]
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_info_json_parse_failure(self):
+        """Test info with invalid JSON output"""
+        self.mock_module.run_command.return_value = (0, 'invalid json', '')
+
+        rc, parsed_output, stderr = self.tool.info('test.qcow2')
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(parsed_output, {})
+        self.assertEqual(len(self.tool.warnings), 1)
+        self.assertIn('Failed to parse JSON output', self.tool.warnings[0])
+
+    def test_info_empty_output(self):
+        """Test info with empty output"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, parsed_output, stderr = self.tool.info('test.qcow2')
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(parsed_output, {})
+        self.assertEqual(len(self.tool.warnings), 0)
+
+    def test_info_whitespace_output(self):
+        """Test info with whitespace-only output"""
+        self.mock_module.run_command.return_value = (0, '   \n  \t  ', '')
+
+        rc, parsed_output, stderr = self.tool.info('test.qcow2')
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(parsed_output, {})
+
+    def test_info_failure(self):
+        """Test info operation failure"""
+        self.mock_module.run_command.return_value = (
+            1, '', 'qemu-img: Could not open file')
+
+        rc, parsed_output, stderr = self.tool.info('nonexistent.qcow2')
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(parsed_output, {})
+        self.assertEqual(stderr, 'qemu-img: Could not open file')
+
+    def test_info_complex_json(self):
+        """Test info with complex JSON output including backing files"""
+        complex_info = {
+            "virtual-size": 2147483648,
+            "filename": "overlay.qcow2",
+            "cluster-size": 65536,
+            "format": "qcow2",
+            "actual-size": 1048576,
+            "backing-filename": "base.qcow2",
+            "backing-filename-format": "qcow2",
+            "format-specific": {
+                "type": "qcow2",
+                "data": {
+                    "compat": "1.1",
+                    "lazy-refcounts": True,
+                    "refcount-bits": 16,
+                    "corrupt": False,
+                    "extended-l2": False
+                }
+            }
+        }
+        self.mock_module.run_command.return_value = (
+            0, json.dumps(complex_info), '')
+
+        rc, parsed_output, stderr = self.tool.info('overlay.qcow2')
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(parsed_output, complex_info)
+        self.assertIn('backing-filename', parsed_output)
+        self.assertEqual(parsed_output['backing-filename'], 'base.qcow2')
+
+
+class TestQemuImgToolResize(unittest.TestCase):
+    """Test QemuImgTool resize method"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+        self.tool = QemuImgTool(self.mock_module)
+
+    def test_resize_basic(self):
+        """Test basic resize operation"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.resize('test.qcow2', '20G')
+
+        expected_cmd = ['qemu-img', 'resize', 'test.qcow2', '20G']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_resize_with_format(self):
+        """Test resize with source format"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.resize(
+            'test.img', '10G', source_format='raw')
+
+        expected_cmd = ['qemu-img', 'resize', '-f', 'raw', 'test.img', '10G']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_resize_with_preallocation(self):
+        """Test resize with preallocation mode"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.resize(
+            'test.qcow2', '30G',
+            preallocation='metadata'
+        )
+
+        expected_cmd = ['qemu-img', 'resize',
+                        '--preallocation', 'metadata', 'test.qcow2', '30G']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_resize_with_shrink(self):
+        """Test resize with shrink option"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.resize(
+            'test.qcow2', '5G',
+            shrink=True
+        )
+
+        expected_cmd = ['qemu-img', 'resize', '--shrink', 'test.qcow2', '5G']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_resize_with_all_options(self):
+        """Test resize with all options"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.resize(
+            'test.qcow2', '15G',
+            source_format='qcow2',
+            preallocation='full',
+            shrink=True
+        )
+
+        expected_cmd = [
+            'qemu-img', 'resize',
+            '-f', 'qcow2',
+            '--preallocation', 'full',
+            '--shrink',
+            'test.qcow2', '15G'
+        ]
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_resize_increase_size(self):
+        """Test resize with size increase (+prefix)"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.resize('test.qcow2', '+5G')
+
+        expected_cmd = ['qemu-img', 'resize', 'test.qcow2', '+5G']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_resize_decrease_size(self):
+        """Test resize with size decrease (-prefix)"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.resize(
+            'test.qcow2', '-500M', shrink=True)
+
+        expected_cmd = ['qemu-img', 'resize',
+                        '--shrink', 'test.qcow2', '-500M']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_resize_different_size_units(self):
+        """Test resize with different size units"""
+        size_units = ['1024', '2k', '3M', '4G', '5T']
+
+        for size in size_units:
+            with self.subTest(size=size):
+                # Reset the tool for each test
+                self.tool = QemuImgTool(self.mock_module)
+                self.mock_module.run_command.return_value = (0, '', '')
+
+                rc, stdout, stderr = self.tool.resize('test.qcow2', size)
+
+                expected_cmd = ['qemu-img', 'resize', 'test.qcow2', size]
+                self.assertEqual(rc, 0)
+                self.mock_module.run_command.assert_called_with(
+                    expected_cmd, check_rc=False)
+
+    def test_resize_failure(self):
+        """Test resize operation failure"""
+        self.mock_module.run_command.return_value = (
+            1, '', 'qemu-img: Could not resize image')
+
+        rc, stdout, stderr = self.tool.resize('test.qcow2', '10G')
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(stderr, 'qemu-img: Could not resize image')
+
+    def test_resize_shrink_without_flag_failure(self):
+        """Test resize shrink without shrink flag (should fail)"""
+        error_msg = 'qemu-img: Use the --shrink option to perform a shrink operation.'
+        self.mock_module.run_command.return_value = (1, '', error_msg)
+
+        rc, stdout, stderr = self.tool.resize(
+            'test.qcow2', '5G')  # No shrink=True
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(stderr, error_msg)
+
+    def test_resize_numeric_size(self):
+        """Test resize with numeric size (should be converted to string)"""
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        rc, stdout, stderr = self.tool.resize(
+            'test.qcow2', 21474836480)  # 20G in bytes
+
+        expected_cmd = ['qemu-img', 'resize', 'test.qcow2', '21474836480']
+        self.assertEqual(rc, 0)
+        self.mock_module.run_command.assert_called_once_with(
+            expected_cmd, check_rc=False)
+
+    def test_resize_preallocation_modes(self):
+        """Test resize with different preallocation modes"""
+        prealloc_modes = ['off', 'metadata', 'falloc', 'full']
+
+        for mode in prealloc_modes:
+            with self.subTest(mode=mode):
+                # Reset the tool for each test
+                self.tool = QemuImgTool(self.mock_module)
+                self.mock_module.run_command.return_value = (0, '', '')
+
+                rc, stdout, stderr = self.tool.resize(
+                    'test.qcow2', '20G',
+                    preallocation=mode
+                )
+
+                expected_cmd = ['qemu-img', 'resize',
+                                '--preallocation', mode, 'test.qcow2', '20G']
+                self.assertEqual(rc, 0)
+                self.mock_module.run_command.assert_called_with(
+                    expected_cmd, check_rc=False)
+
+
+class TestQemuImgToolIntegration(unittest.TestCase):
+    """Integration tests for QemuImgTool"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+
+    def test_automatic_command_reset(self):
+        """Test that command_argv is automatically reset for each operation"""
+        tool = QemuImgTool(self.mock_module)
+        self.mock_module.run_command.return_value = (
+            0, '{"format": "qcow2"}', '')
+
+        # Verify initial state
+        self.assertEqual(tool.command_argv, ['qemu-img'])
+        self.assertEqual(tool._base_command, 'qemu-img')
+
+        # First operation: info
+        tool.info('test.qcow2')
+        first_call = self.mock_module.run_command.call_args[0][0]
+        expected_first = ['qemu-img', 'info', '--output', 'json', 'test.qcow2']
+        self.assertEqual(first_call, expected_first)
+
+        # Second operation: convert (should start fresh)
+        tool.convert('input.qcow2', 'output.qcow2', compressed=True)
+        second_call = self.mock_module.run_command.call_args[0][0]
+        expected_second = ['qemu-img', 'convert',
+                           '-c', 'input.qcow2', 'output.qcow2']
+        self.assertEqual(second_call, expected_second)
+
+        # Third operation: resize (should start fresh)
+        tool.resize('test.qcow2', '20G', shrink=True)
+        third_call = self.mock_module.run_command.call_args[0][0]
+        expected_third = ['qemu-img', 'resize',
+                          '--shrink', 'test.qcow2', '20G']
+        self.assertEqual(third_call, expected_third)
+
+    def test_automatic_command_reset_custom_tool(self):
+        """Test automatic reset works with custom tool command"""
+        custom_cmd = '/opt/qemu/bin/qemu-img'
+        tool = QemuImgTool(self.mock_module, qemu_img_path=custom_cmd)
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        # Verify initial state with custom command
+        self.assertEqual(tool.command_argv, [custom_cmd])
+        self.assertEqual(tool._base_command, custom_cmd)
+
+        # First operation
+        tool.info('test.qcow2')
+        first_call = self.mock_module.run_command.call_args[0][0]
+        self.assertEqual(first_call[0], custom_cmd)
+
+        # Second operation should reset to custom command
+        tool.convert('input.qcow2', 'output.qcow2')
+        second_call = self.mock_module.run_command.call_args[0][0]
+        self.assertEqual(second_call[0], custom_cmd)
+        self.assertEqual(second_call[1], 'convert')
+
+    def test_multiple_operations_same_instance(self):
+        """Test performing multiple operations with the same instance"""
+        tool = QemuImgTool(self.mock_module)
+
+        # First operation: info
+        self.mock_module.run_command.return_value = (
+            0, '{"format": "qcow2"}', '')
+        rc1, output1, stderr1 = tool.info('test.qcow2')
+
+        # Second operation: resize (should automatically reset command_argv)
+        self.mock_module.run_command.return_value = (0, '', '')
+        rc2, output2, stderr2 = tool.resize('test.qcow2', '20G')
+
+        # Third operation: convert (should automatically reset command_argv)
+        self.mock_module.run_command.return_value = (0, '', '')
+        rc3, output3, stderr3 = tool.convert('test.qcow2', 'output.qcow2')
+
+        # Verify all operations succeeded
+        self.assertEqual(rc1, 0)
+        self.assertEqual(rc2, 0)
+        self.assertEqual(rc3, 0)
+        self.assertEqual(output1, {"format": "qcow2"})
+
+    def test_command_argv_isolation(self):
+        """Test that command_argv is properly isolated between operations"""
+        tool = QemuImgTool(self.mock_module)
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        # First operation should not affect subsequent operations
+        tool.convert('input.qcow2', 'output1.qcow2', compressed=True)
+        first_call_args = self.mock_module.run_command.call_args[0][0]
+
+        # Second operation (should automatically reset command_argv)
+        tool.convert('input.qcow2', 'output2.qcow2')  # No compression
+        second_call_args = self.mock_module.run_command.call_args[0][0]
+
+        # First call should have compression flag, second should not
+        self.assertIn('-c', first_call_args)
+        self.assertNotIn('-c', second_call_args)
+
+    def test_warnings_accumulation(self):
+        """Test that warnings accumulate across operations"""
+        tool = QemuImgTool(self.mock_module)
+
+        # First operation with invalid JSON
+        self.mock_module.run_command.return_value = (0, 'invalid json 1', '')
+        tool.info('test1.qcow2')
+
+        # Second operation with invalid JSON
+        self.mock_module.run_command.return_value = (0, 'invalid json 2', '')
+        tool.info('test2.qcow2')
+
+        # Should have two warnings
+        self.assertEqual(len(tool.warnings), 2)
+        self.assertIn('Failed to parse JSON output', tool.warnings[0])
+        self.assertIn('Failed to parse JSON output', tool.warnings[1])
+
+    def test_custom_command_path(self):
+        """Test using custom qemu-img command path"""
+        custom_path = '/opt/qemu/bin/qemu-img'
+        tool = QemuImgTool(self.mock_module, qemu_img_path=custom_path)
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        tool.info('test.qcow2')
+
+        called_cmd = self.mock_module.run_command.call_args[0][0]
+        self.assertEqual(called_cmd[0], custom_path)
+
+    def test_error_handling_consistency(self):
+        """Test consistent error handling across all methods"""
+        tool = QemuImgTool(self.mock_module)
+        error_rc = 2
+        error_message = 'Generic qemu-img error'
+        self.mock_module.run_command.return_value = (
+            error_rc, '', error_message)
+
+        # Test all methods return the same error code and message
+        rc1, stdout1, stderr1 = tool.convert('input.qcow2', 'output.qcow2')
+        rc2, stdout2, stderr2 = tool.info('test.qcow2')
+        rc3, stdout3, stderr3 = tool.resize('test.qcow2', '10G')
+
+        self.assertEqual(rc1, error_rc)
+        self.assertEqual(rc2, error_rc)
+        self.assertEqual(rc3, error_rc)
+        self.assertEqual(stderr1, error_message)
+        self.assertEqual(stderr2, error_message)
+        self.assertEqual(stderr3, error_message)
+
+    def test_check_mode_convert(self):
+        """Test that convert respects check_mode"""
+        tool = QemuImgTool(self.mock_module)
+        self.mock_module.check_mode = True
+
+        # In check mode, command should not be executed
+        rc, stdout, stderr = tool.convert(
+            'input.qcow2', 'output.qcow2', compressed=True)
+
+        # Should return success with descriptive message
+        self.assertEqual(rc, 0)
+        self.assertIn(
+            'Would convert image from input.qcow2 to output.qcow2', stdout)
+        self.assertEqual(stderr, '')
+
+        # run_command should not have been called
+        self.mock_module.run_command.assert_not_called()
+
+    def test_check_mode_resize(self):
+        """Test that resize respects check_mode"""
+        tool = QemuImgTool(self.mock_module)
+        self.mock_module.check_mode = True
+
+        # In check mode, command should not be executed
+        rc, stdout, stderr = tool.resize('test.qcow2', '20G', shrink=True)
+
+        # Should return success with descriptive message
+        self.assertEqual(rc, 0)
+        self.assertIn('Would resize image test.qcow2 to 20G', stdout)
+        self.assertEqual(stderr, '')
+
+        # run_command should not have been called
+        self.mock_module.run_command.assert_not_called()
+
+    def test_check_mode_info_not_affected(self):
+        """Test that info command is not affected by check_mode"""
+        tool = QemuImgTool(self.mock_module)
+        self.mock_module.check_mode = True
+        self.mock_module.run_command.return_value = (
+            0, '{"format": "qcow2"}', '')
+
+        # Info should still execute even in check mode (read-only operation)
+        rc, output, stderr = tool.info('test.qcow2')
+
+        # Should execute normally and return parsed output
+        self.assertEqual(rc, 0)
+        self.assertEqual(output, {"format": "qcow2"})
+        self.assertEqual(stderr, '')
+
+        # run_command should have been called for info (read-only)
+        self.mock_module.run_command.assert_called_once()
+
+    def test_check_mode_false_normal_execution(self):
+        """Test that operations execute normally when check_mode is False"""
+        tool = QemuImgTool(self.mock_module)
+        self.mock_module.check_mode = False
+        self.mock_module.run_command.return_value = (0, '', '')
+
+        # All operations should execute normally
+        rc1, stdout1, stderr1 = tool.convert('input.qcow2', 'output.qcow2')
+        rc2, stdout2, stderr2 = tool.resize('test.qcow2', '20G')
+
+        # Should return normal command output, not check_mode messages
+        self.assertEqual(rc1, 0)
+        self.assertEqual(rc2, 0)
+        self.assertNotIn('Would convert', stdout1)
+        self.assertNotIn('Would resize', stdout2)
+
+        # run_command should have been called twice
+        self.assertEqual(self.mock_module.run_command.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/unit/modules/test_virt_cloud_instance.py
+++ b/tests/unit/modules/test_virt_cloud_instance.py
@@ -1,0 +1,1266 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+
+import os
+
+from ansible_collections.community.libvirt.tests.unit.compat import mock
+from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import BaseImageOperator
+
+
+class TestBaseImageOperatorInit(unittest.TestCase):
+    """Test BaseImageOperator initialization"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.tmpdir = '/tmp/ansible_test'
+        self.mock_module.check_mode = False
+
+    def test_init_with_required_params(self):
+        """Test initialization with required parameters only"""
+        operator = BaseImageOperator(self.mock_module, '/path/to/image.qcow2')
+
+        self.assertEqual(operator.module, self.mock_module)
+        self.assertEqual(operator.base_image, '/path/to/image.qcow2')
+        self.assertIsNone(operator.image_cache_dir)
+        self.assertIsNone(operator.image_checksum)
+        self.assertIsNone(operator.base_image_path)
+        self.assertIsNone(operator.system_disk_path)
+
+    def test_init_with_all_params(self):
+        """Test initialization with all parameters"""
+        operator = BaseImageOperator(
+            self.mock_module,
+            'https://example.com/image.qcow2',
+            image_cache_dir='/var/cache/images',
+            image_checksum='sha256:abc123'
+        )
+
+        self.assertEqual(operator.module, self.mock_module)
+        self.assertEqual(operator.base_image,
+                         'https://example.com/image.qcow2')
+        self.assertEqual(operator.image_cache_dir, '/var/cache/images')
+        self.assertEqual(operator.image_checksum, 'sha256:abc123')
+        self.assertIsNone(operator.base_image_path)
+        self.assertIsNone(operator.system_disk_path)
+
+
+class TestBaseImageOperatorFetchImage(unittest.TestCase):
+    """Test BaseImageOperator fetch_image method"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.tmpdir = '/tmp/ansible_test'
+        self.mock_module.check_mode = False
+        self.mock_module.atomic_move = mock.Mock()
+
+    def test_fetch_image_local_file_exists(self):
+        """Test fetching local file that exists"""
+        operator = BaseImageOperator(
+            self.mock_module, '/path/to/local/image.qcow2')
+
+        with mock.patch('os.path.exists', return_value=True):
+            result = operator.fetch_image(force_pull=False)
+
+            self.assertEqual(result, '/path/to/local/image.qcow2')
+            self.assertEqual(operator.base_image_path,
+                             '/path/to/local/image.qcow2')
+            self.mock_module.fail_json.assert_not_called()
+
+    def test_fetch_image_local_file_not_exists(self):
+        """Test fetching local file that doesn't exist"""
+        operator = BaseImageOperator(
+            self.mock_module, '/path/to/nonexistent.qcow2')
+
+        with mock.patch('os.path.exists', return_value=False):
+            operator.fetch_image(force_pull=False)
+
+            self.mock_module.fail_json.assert_called_once_with(
+                msg="Base image file does not exist: /path/to/nonexistent.qcow2"
+            )
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_file')
+    def test_fetch_image_remote_url_no_cache(self, mock_fetch_file):
+        """Test fetching remote URL without cache directory"""
+        operator = BaseImageOperator(
+            self.mock_module, 'https://example.com/image.qcow2')
+        mock_fetch_file.return_value = '/tmp/downloaded_file'
+
+        result = operator.fetch_image(force_pull=False, timeout=30)
+
+        expected_path = os.path.join(self.mock_module.tmpdir, 'image.qcow2')
+        self.assertEqual(result, expected_path)
+        self.assertEqual(operator.base_image_path, expected_path)
+        mock_fetch_file.assert_called_once_with(
+            self.mock_module, 'https://example.com/image.qcow2', timeout=30
+        )
+        self.mock_module.atomic_move.assert_called_once_with(
+            '/tmp/downloaded_file', expected_path)
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_file')
+    def test_fetch_image_remote_url_with_cache_not_exists(self, mock_fetch_file):
+        """Test fetching remote URL with cache directory, file not cached"""
+        operator = BaseImageOperator(
+            self.mock_module,
+            'https://example.com/image.qcow2',
+            image_cache_dir='/var/cache'
+        )
+        mock_fetch_file.return_value = '/tmp/downloaded_file'
+
+        with mock.patch('os.path.exists', return_value=False):
+            result = operator.fetch_image(force_pull=False)
+
+            expected_path = '/var/cache/image.qcow2'
+            self.assertEqual(result, expected_path)
+            self.assertEqual(operator.base_image_path, expected_path)
+            mock_fetch_file.assert_called_once()
+            self.mock_module.atomic_move.assert_called_once_with(
+                '/tmp/downloaded_file', expected_path)
+
+    def test_fetch_image_remote_url_with_cache_exists_no_force(self):
+        """Test fetching remote URL with cache directory, file exists, no force pull"""
+        operator = BaseImageOperator(
+            self.mock_module,
+            'https://example.com/image.qcow2',
+            image_cache_dir='/var/cache'
+        )
+
+        with mock.patch('os.path.exists', return_value=True):
+            result = operator.fetch_image(force_pull=False)
+
+            expected_path = '/var/cache/image.qcow2'
+            self.assertEqual(result, expected_path)
+            self.assertEqual(operator.base_image_path, expected_path)
+            self.mock_module.atomic_move.assert_not_called()
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_file')
+    def test_fetch_image_remote_url_with_cache_exists_force_pull(self, mock_fetch_file):
+        """Test fetching remote URL with cache directory, file exists, force pull enabled"""
+        operator = BaseImageOperator(
+            self.mock_module,
+            'https://example.com/image.qcow2',
+            image_cache_dir='/var/cache'
+        )
+        mock_fetch_file.return_value = '/tmp/downloaded_file'
+
+        with mock.patch('os.path.exists', return_value=True):
+            result = operator.fetch_image(force_pull=True)
+
+            expected_path = '/var/cache/image.qcow2'
+            self.assertEqual(result, expected_path)
+            self.assertEqual(operator.base_image_path, expected_path)
+            mock_fetch_file.assert_called_once()
+            self.mock_module.atomic_move.assert_called_once_with(
+                '/tmp/downloaded_file', expected_path)
+
+    def test_fetch_image_url_without_filename(self):
+        """Test fetching URL without filename"""
+        operator = BaseImageOperator(self.mock_module, 'https://example.com/')
+
+        # Make fail_json raise an exception to simulate real behavior
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        with self.assertRaises(Exception):
+            operator.fetch_image(force_pull=False)
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="Failed to determine filename from base image URL: https://example.com/"
+        )
+
+    def test_fetch_image_unsupported_scheme(self):
+        """Test fetching with unsupported URL scheme (should be treated as local file)"""
+        operator = BaseImageOperator(
+            self.mock_module, 'file:///path/to/image.qcow2')
+
+        with mock.patch('os.path.exists', return_value=True):
+            result = operator.fetch_image(force_pull=False)
+
+            self.assertEqual(result, 'file:///path/to/image.qcow2')
+            self.assertEqual(operator.base_image_path,
+                             'file:///path/to/image.qcow2')
+
+
+class TestBaseImageOperatorResolveSystemDisk(unittest.TestCase):
+    """Test BaseImageOperator _resolve_system_disk method"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+        self.operator = BaseImageOperator(
+            self.mock_module, '/path/to/image.qcow2')
+
+    def test_resolve_system_disk_with_path(self):
+        """Test resolving system disk with path parameter"""
+        disk_param = {'path': '/var/lib/libvirt/images/vm.qcow2', 'size': 20}
+
+        result = self.operator._resolve_system_disk(disk_param)
+
+        self.assertEqual(result, disk_param)
+        self.assertEqual(self.operator.system_disk_path,
+                         '/var/lib/libvirt/images/vm.qcow2')
+
+    def test_resolve_system_disk_without_path(self):
+        """Test resolving system disk without path parameter"""
+        disk_param = {'size': 20}
+
+        with self.assertRaises(ValueError) as context:
+            self.operator._resolve_system_disk(disk_param)
+
+        self.assertEqual(str(context.exception),
+                         "The first disk must have a path to import the cloud image")
+
+    def test_resolve_system_disk_empty_path(self):
+        """Test resolving system disk with empty path"""
+        disk_param = {'path': '', 'size': 20}
+
+        with self.assertRaises(ValueError) as context:
+            self.operator._resolve_system_disk(disk_param)
+
+        self.assertEqual(str(context.exception),
+                         "The first disk must have a path to import the cloud image")
+
+    def test_resolve_system_disk_none_path(self):
+        """Test resolving system disk with None path"""
+        disk_param = {'path': None, 'size': 20}
+
+        with self.assertRaises(ValueError) as context:
+            self.operator._resolve_system_disk(disk_param)
+
+        self.assertEqual(str(context.exception),
+                         "The first disk must have a path to import the cloud image")
+
+
+class TestBaseImageOperatorValidateChecksum(unittest.TestCase):
+    """Test BaseImageOperator validate_checksum method"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+        self.mock_module.digest_from_file = mock.Mock()
+
+    def test_validate_checksum_no_checksum(self):
+        """Test validation when no checksum is specified"""
+        operator = BaseImageOperator(self.mock_module, '/path/to/image.qcow2')
+
+        result = operator.validate_checksum()
+
+        self.assertTrue(result)
+
+    def test_validate_checksum_no_base_image_path(self):
+        """Test validation when base image path is not set"""
+        operator = BaseImageOperator(
+            self.mock_module,
+            '/path/to/image.qcow2',
+            image_checksum='sha256:abc123'
+        )
+
+        operator.validate_checksum()
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="Base image path not found for checksum validation"
+        )
+
+    @mock.patch('os.path.exists', return_value=False)
+    def test_validate_checksum_file_not_exists(self, mock_exists):
+        """Test validation when base image file doesn't exist"""
+        operator = BaseImageOperator(
+            self.mock_module,
+            '/path/to/image.qcow2',
+            image_checksum='sha256:abc123'
+        )
+        operator.base_image_path = '/path/to/image.qcow2'
+
+        operator.validate_checksum()
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="Base image path not found for checksum validation"
+        )
+
+    def test_validate_checksum_invalid_format(self):
+        """Test validation with invalid checksum format"""
+        operator = BaseImageOperator(
+            self.mock_module,
+            '/path/to/image.qcow2',
+            image_checksum='invalidformat'
+        )
+        operator.base_image_path = '/path/to/image.qcow2'
+
+        # Make fail_json raise an exception to simulate real behavior
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        with mock.patch('os.path.exists', return_value=True):
+            with self.assertRaises(Exception):
+                operator.validate_checksum()
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="The image_checksum parameter has to be in format <algorithm>:<checksum>"
+        )
+
+    @mock.patch('os.path.exists', return_value=True)
+    def test_validate_checksum_invalid_hex(self, mock_exists):
+        """Test validation with invalid hex checksum"""
+        operator = BaseImageOperator(
+            self.mock_module,
+            '/path/to/image.qcow2',
+            image_checksum='sha256:invalid_hex_xyz'
+        )
+        operator.base_image_path = '/path/to/image.qcow2'
+
+        operator.validate_checksum()
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg='The checksum format is invalid'
+        )
+
+    @mock.patch('os.path.exists', return_value=True)
+    def test_validate_checksum_successful_match(self, mock_exists):
+        """Test successful checksum validation"""
+        expected_checksum = 'abc123def456'
+        operator = BaseImageOperator(
+            self.mock_module,
+            '/path/to/image.qcow2',
+            image_checksum=f'sha256:{expected_checksum}'
+        )
+        operator.base_image_path = '/path/to/image.qcow2'
+        self.mock_module.digest_from_file.return_value = expected_checksum
+
+        result = operator.validate_checksum()
+
+        self.assertTrue(result)
+        self.mock_module.digest_from_file.assert_called_once_with(
+            '/path/to/image.qcow2', 'sha256'
+        )
+
+    @mock.patch('os.path.exists', return_value=True)
+    def test_validate_checksum_mismatch(self, mock_exists):
+        """Test checksum validation with mismatch"""
+        operator = BaseImageOperator(
+            self.mock_module,
+            '/path/to/image.qcow2',
+            image_checksum='sha256:abc123def456'
+        )
+        operator.base_image_path = '/path/to/image.qcow2'
+        self.mock_module.digest_from_file.return_value = 'different_checksum'
+
+        result = operator.validate_checksum()
+
+        self.assertFalse(result)
+
+    @mock.patch('os.path.exists', return_value=True)
+    def test_validate_checksum_digest_error(self, mock_exists):
+        """Test checksum validation with digest calculation error"""
+        operator = BaseImageOperator(
+            self.mock_module,
+            '/path/to/image.qcow2',
+            image_checksum='sha256:abc123def456'
+        )
+        operator.base_image_path = '/path/to/image.qcow2'
+        self.mock_module.digest_from_file.side_effect = ValueError(
+            "Unsupported algorithm")
+
+        # Make fail_json raise an exception to simulate real behavior
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        with self.assertRaises(Exception):
+            operator.validate_checksum()
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="Failed to calculate the actual checksum of the file: Unsupported algorithm"
+        )
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_url')
+    @mock.patch('os.path.exists', return_value=True)
+    def test_validate_checksum_from_url(self, mock_exists, mock_fetch_url):
+        """Test checksum validation from URL"""
+        # Mock the response object
+        mock_response = mock.Mock()
+        mock_response.read.return_value = b'abc123def456  image.qcow2\n'
+        mock_fetch_url.return_value = (mock_response, {})
+
+        operator = BaseImageOperator(
+            self.mock_module,
+            'https://example.com/image.qcow2',
+            image_checksum='sha256:https://example.com/checksums.sha256'
+        )
+        operator.base_image_path = '/path/to/image.qcow2'
+        self.mock_module.digest_from_file.return_value = 'abc123def456'
+
+        result = operator.validate_checksum()
+
+        self.assertTrue(result)
+        mock_fetch_url.assert_called_once_with(
+            self.mock_module, 'https://example.com/checksums.sha256', timeout=60
+        )
+
+    @mock.patch('os.path.exists', return_value=True)
+    def test_validate_checksum_whitespace_handling(self, mock_exists):
+        """Test checksum validation with whitespace in checksum"""
+        operator = BaseImageOperator(
+            self.mock_module,
+            '/path/to/image.qcow2',
+            image_checksum='sha256: abc 123 def 456 '
+        )
+        operator.base_image_path = '/path/to/image.qcow2'
+        self.mock_module.digest_from_file.return_value = 'abc123def456'
+
+        result = operator.validate_checksum()
+
+        self.assertTrue(result)
+
+
+class TestBaseImageOperatorFetchChecksumFromUrl(unittest.TestCase):
+    """Test BaseImageOperator _fetch_checksum_from_url method"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+        self.operator = BaseImageOperator(
+            self.mock_module,
+            'https://example.com/image.qcow2'
+        )
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_url')
+    def test_fetch_checksum_single_line_format(self, mock_fetch_url):
+        """Test fetching checksum from single-line format"""
+        mock_response = mock.Mock()
+        mock_response.read.return_value = b'abc123def456'
+        mock_fetch_url.return_value = (mock_response, {})
+
+        result = self.operator._fetch_checksum_from_url(
+            'https://example.com/checksum.txt', 'sha256'
+        )
+
+        self.assertEqual(result, 'abc123def456')
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_url')
+    def test_fetch_checksum_multi_line_format(self, mock_fetch_url):
+        """Test fetching checksum from multi-line format"""
+        checksum_content = (
+            'abc123def456  image.qcow2\n'
+            'def456ghi789  other.qcow2\n'
+        )
+        mock_response = mock.Mock()
+        mock_response.read.return_value = checksum_content.encode()
+        mock_fetch_url.return_value = (mock_response, {})
+
+        result = self.operator._fetch_checksum_from_url(
+            'https://example.com/checksums.txt', 'sha256'
+        )
+
+        self.assertEqual(result, 'abc123def456')
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_url')
+    def test_fetch_checksum_binary_mode_marker(self, mock_fetch_url):
+        """Test fetching checksum with binary mode marker"""
+        checksum_content = 'abc123def456 *image.qcow2\n'
+        mock_response = mock.Mock()
+        mock_response.read.return_value = checksum_content.encode()
+        mock_fetch_url.return_value = (mock_response, {})
+
+        result = self.operator._fetch_checksum_from_url(
+            'https://example.com/checksums.txt', 'sha256'
+        )
+
+        self.assertEqual(result, 'abc123def456')
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_url')
+    def test_fetch_checksum_with_path_prefix(self, mock_fetch_url):
+        """Test fetching checksum with path prefix"""
+        checksum_content = 'abc123def456  ./image.qcow2\n'
+        mock_response = mock.Mock()
+        mock_response.read.return_value = checksum_content.encode()
+        mock_fetch_url.return_value = (mock_response, {})
+
+        result = self.operator._fetch_checksum_from_url(
+            'https://example.com/checksums.txt', 'sha256'
+        )
+
+        self.assertEqual(result, 'abc123def456')
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_url')
+    def test_fetch_checksum_file_not_found(self, mock_fetch_url):
+        """Test fetching checksum when file is not found in checksum file"""
+        checksum_content = 'abc123def456  other.qcow2\n'
+        mock_response = mock.Mock()
+        mock_response.read.return_value = checksum_content.encode()
+        mock_fetch_url.return_value = (mock_response, {})
+
+        self.operator._fetch_checksum_from_url(
+            'https://example.com/checksums.txt', 'sha256'
+        )
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="Unable to find a checksum for file 'image.qcow2' in 'https://example.com/checksums.txt'"
+        )
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_url')
+    def test_fetch_checksum_download_failure(self, mock_fetch_url):
+        """Test fetching checksum when download fails"""
+        mock_fetch_url.return_value = (None, {'msg': 'Connection failed'})
+
+        # Make fail_json raise an exception to simulate real behavior
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        with self.assertRaises(Exception):
+            self.operator._fetch_checksum_from_url(
+                'https://example.com/checksums.txt', 'sha256'
+            )
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="Failed to download checksum from https://example.com/checksums.txt: Connection failed"
+        )
+
+
+class TestBaseImageOperatorBuildSystemDisk(unittest.TestCase):
+    """Test BaseImageOperator build_system_disk method"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+        self.mock_module.preserved_copy = mock.Mock()
+        self.operator = BaseImageOperator(
+            self.mock_module, '/path/to/image.qcow2')
+        self.operator.base_image_path = '/path/to/base.qcow2'
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.QemuImgTool')
+    @mock.patch('os.path.exists')
+    def test_build_system_disk_basic(self, mock_exists, mock_qemu_tool_class):
+        """Test basic system disk building"""
+        mock_exists.return_value = False  # System disk doesn't exist
+
+        # Configure the mocked QemuImgTool
+        mock_qemu_instance = mock.Mock()
+        mock_qemu_tool_class.return_value = mock_qemu_instance
+        mock_qemu_instance.info.return_value = (0, {
+            'format': 'qcow2',
+            'virtual-size': 1073741824  # 1GB
+        }, '')
+        mock_qemu_instance.resize.return_value = (0, '', '')
+
+        disk_param = {
+            'path': '/var/lib/libvirt/images/vm.qcow2',
+            'size': 20,
+            'format': 'qcow2'
+        }
+
+        result = self.operator.build_system_disk(disk_param)
+
+        self.assertEqual(result, disk_param)
+        self.assertEqual(self.operator.system_disk_path,
+                         '/var/lib/libvirt/images/vm.qcow2')
+        mock_qemu_instance.info.assert_called_once_with('/path/to/base.qcow2')
+        self.mock_module.preserved_copy.assert_called_once_with(
+            '/path/to/base.qcow2', '/var/lib/libvirt/images/vm.qcow2'
+        )
+        mock_qemu_instance.resize.assert_called_once_with(
+            '/var/lib/libvirt/images/vm.qcow2', '20G'
+        )
+
+    @mock.patch('os.path.exists')
+    def test_build_system_disk_already_exists(self, mock_exists):
+        """Test building system disk when target already exists"""
+        mock_exists.return_value = True
+
+        # Make fail_json raise an exception to simulate real behavior
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        disk_param = {
+            'path': '/var/lib/libvirt/images/vm.qcow2',
+            'size': 20
+        }
+
+        with self.assertRaises(Exception):
+            self.operator.build_system_disk(disk_param)
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="The system disk file already exists: /var/lib/libvirt/images/vm.qcow2"
+        )
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.QemuImgTool')
+    @mock.patch('os.path.exists')
+    def test_build_system_disk_info_failure(self, mock_exists, mock_qemu_tool_class):
+        """Test building system disk when qemu-img info fails"""
+        mock_exists.return_value = False
+
+        # Configure the mocked QemuImgTool to return failure
+        mock_qemu_instance = mock.Mock()
+        mock_qemu_tool_class.return_value = mock_qemu_instance
+        mock_qemu_instance.info.return_value = (
+            1, {}, 'Failed to get image info')
+
+        # Make fail_json raise an exception to simulate real behavior
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        disk_param = {
+            'path': '/var/lib/libvirt/images/vm.qcow2',
+            'size': 20
+        }
+
+        with self.assertRaises(Exception):
+            self.operator.build_system_disk(disk_param)
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="Failed to get base image info: Failed to get image info"
+        )
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.QemuImgTool')
+    @mock.patch('os.path.exists')
+    def test_build_system_disk_no_format(self, mock_exists, mock_qemu_tool_class):
+        """Test building system disk when base image has no format"""
+        mock_exists.return_value = False
+
+        # Configure the mocked QemuImgTool to return no format
+        mock_qemu_instance = mock.Mock()
+        mock_qemu_tool_class.return_value = mock_qemu_instance
+        mock_qemu_instance.info.return_value = (0, {
+            'virtual-size': 1073741824
+        }, '')
+
+        # Make fail_json raise an exception to simulate real behavior
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        disk_param = {
+            'path': '/var/lib/libvirt/images/vm.qcow2',
+            'size': 20
+        }
+
+        with self.assertRaises(Exception):
+            self.operator.build_system_disk(disk_param)
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="No valid format found for the base image: /path/to/base.qcow2"
+        )
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.QemuImgTool')
+    @mock.patch('os.path.exists')
+    def test_build_system_disk_invalid_size(self, mock_exists, mock_qemu_tool_class):
+        """Test building system disk with invalid size"""
+        mock_exists.return_value = False
+
+        # Configure the mocked QemuImgTool
+        mock_qemu_instance = mock.Mock()
+        mock_qemu_tool_class.return_value = mock_qemu_instance
+        mock_qemu_instance.info.return_value = (0, {
+            'format': 'qcow2',
+            'virtual-size': 1073741824
+        }, '')
+
+        # Make fail_json raise an exception to simulate real behavior
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        disk_param = {
+            'path': '/var/lib/libvirt/images/vm.qcow2',
+            'size': 'invalid'
+        }
+
+        with self.assertRaises(Exception):
+            self.operator.build_system_disk(disk_param)
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="The system disk size must be an integer"
+        )
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.QemuImgTool')
+    @mock.patch('os.path.exists')
+    def test_build_system_disk_size_too_small(self, mock_exists, mock_qemu_tool_class):
+        """Test building system disk when size is too small"""
+        mock_exists.return_value = False
+
+        # Configure the mocked QemuImgTool
+        mock_qemu_instance = mock.Mock()
+        mock_qemu_tool_class.return_value = mock_qemu_instance
+        mock_qemu_instance.info.return_value = (0, {
+            'format': 'qcow2',
+            'virtual-size': 21474836480  # 20GB
+        }, '')
+
+        # Make fail_json raise an exception to simulate real behavior
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        disk_param = {
+            'path': '/var/lib/libvirt/images/vm.qcow2',
+            'size': 10  # 10GB, smaller than base image
+        }
+
+        with self.assertRaises(Exception):
+            self.operator.build_system_disk(disk_param)
+
+        expected_system_size = 10 * 1024 * 1024 * 1024
+        self.mock_module.fail_json.assert_called_once_with(
+            msg=f"The system disk size is too small to import the base image: {expected_system_size} < 21474836480"
+        )
+
+
+class TestBaseImageOperatorCheckMode(unittest.TestCase):
+    """Test BaseImageOperator check_mode support"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.tmpdir = '/tmp/ansible_test'
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_file')
+    @mock.patch('os.path.exists')
+    def test_fetch_image_check_mode_local_file(self, mock_exists, mock_fetch_file):
+        """Test fetch_image with check_mode for local file"""
+        self.mock_module.check_mode = True
+        mock_exists.return_value = True
+
+        operator = BaseImageOperator(
+            self.mock_module, '/path/to/local/image.qcow2')
+        result = operator.fetch_image(force_pull=False)
+
+        # Local files should still be processed in check_mode
+        self.assertEqual(result, '/path/to/local/image.qcow2')
+        mock_fetch_file.assert_not_called()
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_file')
+    @mock.patch('os.path.exists')
+    def test_fetch_image_check_mode_url(self, mock_exists, mock_fetch_file):
+        """Test fetch_image with check_mode for URL"""
+        self.mock_module.check_mode = True
+        mock_exists.return_value = False
+
+        operator = BaseImageOperator(
+            self.mock_module, 'https://example.com/image.qcow2')
+        result = operator.fetch_image(force_pull=False)
+
+        # URL downloads should be skipped in check_mode
+        expected_path = '/tmp/ansible_test/image.qcow2'
+        self.assertEqual(result, expected_path)
+        self.assertEqual(operator.base_image_path, expected_path)
+        mock_fetch_file.assert_not_called()
+        self.mock_module.atomic_move.assert_not_called()
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.fetch_file')
+    @mock.patch('os.path.exists')
+    def test_fetch_image_normal_mode_url(self, mock_exists, mock_fetch_file):
+        """Test fetch_image with normal mode for URL"""
+        self.mock_module.check_mode = False
+        mock_exists.return_value = False
+        mock_fetch_file.return_value = '/tmp/temp_image'
+
+        operator = BaseImageOperator(
+            self.mock_module, 'https://example.com/image.qcow2')
+        result = operator.fetch_image(force_pull=False)
+
+        # Normal mode should download the file
+        expected_path = '/tmp/ansible_test/image.qcow2'
+        self.assertEqual(result, expected_path)
+        mock_fetch_file.assert_called_once()
+        self.mock_module.atomic_move.assert_called_once_with(
+            '/tmp/temp_image', expected_path)
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.QemuImgTool')
+    @mock.patch('os.path.exists')
+    def test_build_system_disk_check_mode(self, mock_exists, mock_qemu_tool_class):
+        """Test build_system_disk with check_mode"""
+        self.mock_module.check_mode = True
+        mock_exists.side_effect = lambda path: False  # System disk doesn't exist
+
+        # Mock QemuImgTool
+        mock_qemu_tool = mock.Mock()
+        mock_qemu_tool_class.return_value = mock_qemu_tool
+
+        operator = BaseImageOperator(self.mock_module, '/path/to/image.qcow2')
+        operator.base_image_path = '/path/to/base.qcow2'
+
+        disk_param = {
+            'path': '/var/lib/libvirt/images/vm.qcow2',
+            'size': 20,
+            'format': 'qcow2'
+        }
+
+        result = operator.build_system_disk(disk_param)
+
+        # Should return disk config without creating files
+        self.assertEqual(result, disk_param)
+
+        # QemuImgTool operations should not be called for file creation
+        mock_qemu_tool.convert.assert_not_called()
+        mock_qemu_tool.resize.assert_not_called()
+        self.mock_module.preserved_copy.assert_not_called()
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.QemuImgTool')
+    @mock.patch('os.path.exists')
+    def test_build_system_disk_check_mode_with_nonexistent_base_image(self, mock_exists, mock_qemu_tool_class):
+        """Test build_system_disk with check_mode when base image doesn't exist"""
+        self.mock_module.check_mode = True
+        mock_exists.side_effect = lambda path: False  # No files exist
+
+        # Mock QemuImgTool
+        mock_qemu_tool = mock.Mock()
+        mock_qemu_tool_class.return_value = mock_qemu_tool
+
+        operator = BaseImageOperator(self.mock_module, '/path/to/image.qcow2')
+        operator.base_image_path = '/path/to/nonexistent/base.qcow2'
+
+        disk_param = {
+            'path': '/var/lib/libvirt/images/vm.qcow2',
+            'size': 20,
+            'format': 'qcow2'
+        }
+
+        result = operator.build_system_disk(disk_param)
+
+        # Should use mock values for validation when base image doesn't exist
+        self.assertEqual(result, disk_param)
+
+        # QemuImgTool.info should not be called since base image doesn't exist
+        mock_qemu_tool.info.assert_not_called()
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.QemuImgTool')
+    @mock.patch('os.path.exists')
+    def test_build_system_disk_normal_mode(self, mock_exists, mock_qemu_tool_class):
+        """Test build_system_disk with normal mode"""
+        self.mock_module.check_mode = False
+        self.mock_module.preserved_copy = mock.Mock()
+        # System disk doesn't exist, base image exists
+        mock_exists.side_effect = lambda path: path != '/var/lib/libvirt/images/vm.qcow2'
+
+        # Mock QemuImgTool
+        mock_qemu_tool = mock.Mock()
+        mock_qemu_tool.info.return_value = (0, {
+            'format': 'qcow2',
+            'virtual-size': 5 * 1024 * 1024 * 1024  # 5GB
+        }, '')
+        mock_qemu_tool.resize.return_value = (0, '', '')
+        mock_qemu_tool_class.return_value = mock_qemu_tool
+
+        operator = BaseImageOperator(self.mock_module, '/path/to/image.qcow2')
+        operator.base_image_path = '/path/to/base.qcow2'
+
+        disk_param = {
+            'path': '/var/lib/libvirt/images/vm.qcow2',
+            'size': 20,
+            'format': 'qcow2'
+        }
+
+        result = operator.build_system_disk(disk_param)
+
+        # Should create files in normal mode
+        self.assertEqual(result, disk_param)
+
+        # File operations should be called
+        self.mock_module.preserved_copy.assert_called_once()
+        mock_qemu_tool.resize.assert_called_once()
+
+    def test_validate_checksum_check_mode_no_file(self):
+        """Test validate_checksum with check_mode when file doesn't exist"""
+        self.mock_module.check_mode = True
+
+        operator = BaseImageOperator(
+            self.mock_module,
+            'https://example.com/image.qcow2',
+            image_checksum='sha256:abc123def456'
+        )
+        operator.base_image_path = '/path/to/nonexistent/image.qcow2'
+
+        # Should return True in check_mode when file doesn't exist
+        result = operator.validate_checksum()
+        self.assertTrue(result)
+
+    @mock.patch('os.path.exists')
+    def test_validate_checksum_check_mode_file_exists(self, mock_exists):
+        """Test validate_checksum with check_mode when file exists locally"""
+        self.mock_module.check_mode = True
+        mock_exists.return_value = True
+        self.mock_module.digest_from_file.return_value = 'abc123def456'
+
+        operator = BaseImageOperator(
+            self.mock_module,
+            '/path/to/local/image.qcow2',
+            image_checksum='sha256:abc123def456'
+        )
+        operator.base_image_path = '/path/to/local/image.qcow2'
+
+        # Should perform actual validation in check_mode when file exists
+        result = operator.validate_checksum()
+        self.assertTrue(result)
+        self.mock_module.digest_from_file.assert_called_once()
+
+    @mock.patch('os.path.exists')
+    def test_validate_checksum_normal_mode(self, mock_exists):
+        """Test validate_checksum with normal mode"""
+        self.mock_module.check_mode = False
+        mock_exists.return_value = False  # File doesn't exist
+
+        # Make fail_json raise an exception
+        self.mock_module.fail_json.side_effect = Exception(
+            "Base image path not found for checksum validation")
+
+        operator = BaseImageOperator(
+            self.mock_module,
+            'https://example.com/image.qcow2',
+            image_checksum='sha256:abc123def456'
+        )
+        operator.base_image_path = '/path/to/nonexistent/image.qcow2'
+
+        # Should fail in normal mode when file doesn't exist
+        with self.assertRaises(Exception):
+            operator.validate_checksum()
+
+        self.mock_module.fail_json.assert_called()
+
+
+class TestCore(unittest.TestCase):
+    """Test core() function"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+
+        # Default successful params
+        self.mock_module.params = {
+            'state': 'present',
+            'name': 'test-vm',
+            'recreate': False,
+            'base_image': 'https://example.com/image.qcow2',
+            'image_cache_dir': '/tmp/cache',
+            'force_pull': False,
+            'disks': [{'path': '/var/lib/libvirt/images/test.qcow2', 'size': 20}],
+            'image_checksum': None,
+            'url_timeout': None
+        }
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.BaseImageOperator')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.LibvirtWrapper')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.validate_disks')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.update_virtinst_params')
+    def test_core_vm_not_exists_create_success(self, mock_update_params, mock_validate_disks,
+                                               mock_libvirt_wrapper_class, mock_virt_install_class,
+                                               mock_base_image_operator_class):
+        """Test core() when VM doesn't exist and creation succeeds"""
+        from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import core, VIRT_SUCCESS
+        from ansible_collections.community.libvirt.plugins.module_utils.libvirt import VMNotFound
+
+        # Mock LibvirtWrapper - VM doesn't exist
+        mock_virt_conn = mock.Mock()
+        mock_virt_conn.find_vm.side_effect = VMNotFound("VM not found")
+        mock_libvirt_wrapper_class.return_value = mock_virt_conn
+
+        # Mock VirtInstallTool
+        mock_virt_install = mock.Mock()
+        mock_virt_install.execute.return_value = (
+            True, VIRT_SUCCESS, {'some': 'data'})
+        mock_virt_install_class.return_value = mock_virt_install
+
+        # Mock BaseImageOperator
+        mock_operator = mock.Mock()
+        mock_operator.validate_checksum.return_value = True
+        mock_operator.build_system_disk.return_value = {
+            'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_base_image_operator_class.return_value = mock_operator
+
+        # Execute core function
+        rc, result = core(self.mock_module)
+
+        # Verify behavior
+        mock_validate_disks.assert_called_once()
+        mock_virt_conn.find_vm.assert_called_once_with('test-vm')
+        mock_operator.fetch_image.assert_called_once_with(False, timeout=None)
+        mock_operator.validate_checksum.assert_called_once()
+        mock_operator.build_system_disk.assert_called_once()
+        mock_update_params.assert_called_once()
+        mock_virt_install.execute.assert_called_once_with(dryrun=False, wait_timeout=None)
+
+        # VM should not be destroyed (doesn't exist)
+        mock_virt_conn.destroy.assert_not_called()
+        mock_virt_conn.undefine.assert_not_called()
+
+        # Should return success
+        self.assertEqual(rc, VIRT_SUCCESS)
+        self.assertTrue(result['changed'])
+        self.assertEqual(result['some'], 'data')
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.BaseImageOperator')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.LibvirtWrapper')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.validate_disks')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.update_virtinst_params')
+    def test_core_vm_exists_no_recreate(self, mock_update_params, mock_validate_disks,
+                                        mock_libvirt_wrapper_class, mock_virt_install_class,
+                                        mock_base_image_operator_class):
+        """Test core() when VM exists and recreate=False"""
+        from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import core, VIRT_SUCCESS
+
+        # Mock LibvirtWrapper - VM exists
+        mock_virt_conn = mock.Mock()
+        mock_vm = mock.Mock()
+        mock_virt_conn.find_vm.return_value = mock_vm
+        mock_libvirt_wrapper_class.return_value = mock_virt_conn
+
+        # Mock VirtInstallTool (shouldn't be called)
+        mock_virt_install = mock.Mock()
+        mock_virt_install_class.return_value = mock_virt_install
+
+        # Execute core function
+        rc, result = core(self.mock_module)
+
+        # Verify behavior
+        mock_validate_disks.assert_called_once()
+        mock_virt_conn.find_vm.assert_called_once_with('test-vm')
+
+        # Should not proceed with VM creation
+        mock_base_image_operator_class.assert_not_called()
+        mock_virt_install.execute.assert_not_called()
+        mock_virt_conn.destroy.assert_not_called()
+        mock_virt_conn.undefine.assert_not_called()
+
+        # Should return success with message
+        self.assertEqual(rc, VIRT_SUCCESS)
+        self.assertFalse(result['changed'])
+        self.assertIn("already exists", result['message'])
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.BaseImageOperator')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.LibvirtWrapper')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.validate_disks')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.update_virtinst_params')
+    def test_core_vm_exists_recreate_active(self, mock_update_params, mock_validate_disks,
+                                            mock_libvirt_wrapper_class, mock_virt_install_class,
+                                            mock_base_image_operator_class):
+        """Test core() when VM exists, recreate=True, and VM is active"""
+        from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import core, VIRT_SUCCESS
+
+        # Set recreate to True
+        self.mock_module.params['recreate'] = True
+
+        # Mock LibvirtWrapper - VM exists and is active
+        mock_virt_conn = mock.Mock()
+        mock_vm = mock.Mock()
+        mock_vm.isActive.return_value = True
+        mock_virt_conn.find_vm.return_value = mock_vm
+        mock_libvirt_wrapper_class.return_value = mock_virt_conn
+
+        # Mock VirtInstallTool
+        mock_virt_install = mock.Mock()
+        mock_virt_install.execute.return_value = (True, VIRT_SUCCESS, {})
+        mock_virt_install_class.return_value = mock_virt_install
+
+        # Mock BaseImageOperator
+        mock_operator = mock.Mock()
+        mock_operator.validate_checksum.return_value = True
+        mock_operator.build_system_disk.return_value = {
+            'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_base_image_operator_class.return_value = mock_operator
+
+        # Execute core function
+        rc, result = core(self.mock_module)
+
+        # Verify VM destruction and recreation
+        mock_virt_conn.find_vm.assert_called_once_with('test-vm')
+        mock_virt_conn.destroy.assert_called_once_with('test-vm')
+        mock_virt_conn.undefine.assert_called_once_with('test-vm')
+
+        # Verify VM recreation
+        mock_operator.fetch_image.assert_called_once()
+        mock_operator.validate_checksum.assert_called_once()
+        mock_operator.build_system_disk.assert_called_once()
+        mock_virt_install.execute.assert_called_once_with(dryrun=False, wait_timeout=None)
+
+        # Should return success
+        self.assertEqual(rc, VIRT_SUCCESS)
+        self.assertTrue(result['changed'])
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.BaseImageOperator')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.LibvirtWrapper')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.validate_disks')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.update_virtinst_params')
+    def test_core_vm_exists_recreate_inactive(self, mock_update_params, mock_validate_disks,
+                                              mock_libvirt_wrapper_class, mock_virt_install_class,
+                                              mock_base_image_operator_class):
+        """Test core() when VM exists, recreate=True, and VM is inactive"""
+        from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import core, VIRT_SUCCESS
+
+        # Set recreate to True
+        self.mock_module.params['recreate'] = True
+
+        # Mock LibvirtWrapper - VM exists but is inactive
+        mock_virt_conn = mock.Mock()
+        mock_vm = mock.Mock()
+        mock_vm.isActive.return_value = False
+        mock_virt_conn.find_vm.return_value = mock_vm
+        mock_libvirt_wrapper_class.return_value = mock_virt_conn
+
+        # Mock VirtInstallTool
+        mock_virt_install = mock.Mock()
+        mock_virt_install.execute.return_value = (True, VIRT_SUCCESS, {})
+        mock_virt_install_class.return_value = mock_virt_install
+
+        # Mock BaseImageOperator
+        mock_operator = mock.Mock()
+        mock_operator.validate_checksum.return_value = True
+        mock_operator.build_system_disk.return_value = {
+            'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_base_image_operator_class.return_value = mock_operator
+
+        # Execute core function
+        rc, result = core(self.mock_module)
+
+        # Verify behavior - should not destroy (inactive), but should undefine
+        mock_virt_conn.destroy.assert_not_called()  # VM is inactive
+        mock_virt_conn.undefine.assert_called_once_with('test-vm')
+
+        # Should return success
+        self.assertEqual(rc, VIRT_SUCCESS)
+        self.assertTrue(result['changed'])
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.LibvirtWrapper')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.validate_disks')
+    def test_core_missing_name(self, mock_validate_disks, mock_libvirt_wrapper_class, mock_virt_install_class):
+        """Test core() fails when VM name is missing"""
+        from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import core
+
+        # Mock the module.run_command for LibvirtConnection
+        self.mock_module.run_command.return_value = (0, 'kernel-version', '')
+
+        # Remove name from params
+        self.mock_module.params['name'] = None
+
+        # Execute core function
+        core(self.mock_module)
+
+        # Should fail with appropriate message
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="virtual machine name is missing")
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.LibvirtWrapper')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.validate_disks')
+    def test_core_missing_base_image(self, mock_validate_disks, mock_libvirt_wrapper_class, mock_virt_install_class):
+        """Test core() fails when base_image is missing"""
+        from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import core
+
+        # Mock the module.run_command for LibvirtConnection
+        self.mock_module.run_command.return_value = (0, 'kernel-version', '')
+
+        # Remove base_image from params
+        self.mock_module.params['base_image'] = None
+
+        # Execute core function
+        core(self.mock_module)
+
+        # Should fail with appropriate message
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="base_image parameter is required")
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.BaseImageOperator')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.LibvirtWrapper')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.validate_disks')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.update_virtinst_params')
+    def test_core_checksum_validation_fails(self, mock_update_params, mock_validate_disks, mock_libvirt_wrapper_class,
+                                            mock_virt_install_class, mock_base_image_operator_class):
+        """Test core() fails when checksum validation fails"""
+        from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import core
+        from ansible_collections.community.libvirt.plugins.module_utils.libvirt import VMNotFound
+
+        # Mock LibvirtWrapper - VM doesn't exist
+        mock_virt_conn = mock.Mock()
+        mock_virt_conn.find_vm.side_effect = VMNotFound("VM not found")
+        mock_libvirt_wrapper_class.return_value = mock_virt_conn
+
+        # Mock VirtInstallTool (shouldn't be used due to checksum failure)
+        mock_virt_install = mock.Mock()
+        mock_virt_install.params = {
+            'disks': [{'path': '/tmp/placeholder.qcow2'}]}
+        mock_virt_install_class.return_value = mock_virt_install
+
+        # Mock BaseImageOperator - checksum validation fails
+        mock_operator = mock.Mock()
+        mock_operator.validate_checksum.return_value = False
+        mock_base_image_operator_class.return_value = mock_operator
+
+        # Configure fail_json to raise exception (as it should in real code)
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        # Execute core function - should raise exception due to checksum failure
+        with self.assertRaises(Exception):
+            core(self.mock_module)
+
+        # Should fail with checksum error
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="The checksum of the base image does not match the expected value")
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.LibvirtWrapper')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.validate_disks')
+    def test_core_unsupported_state(self, mock_validate_disks, mock_libvirt_wrapper_class, mock_virt_install_class):
+        """Test core() fails with unsupported state"""
+        from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import core
+
+        # Mock the module.run_command for LibvirtConnection
+        self.mock_module.run_command.return_value = (0, 'kernel-version', '')
+
+        # Set unsupported state
+        self.mock_module.params['state'] = 'destroy'
+
+        # Execute core function
+        core(self.mock_module)
+
+        # Should fail with unsupported state message
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="unsupported state 'destroy'")
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.BaseImageOperator')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.LibvirtWrapper')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.validate_disks')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.update_virtinst_params')
+    def test_core_check_mode_vm_recreation(self, mock_update_params, mock_validate_disks,
+                                           mock_libvirt_wrapper_class, mock_virt_install_class,
+                                           mock_base_image_operator_class):
+        """Test core() in check_mode when recreating VM"""
+        from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import core, VIRT_SUCCESS
+
+        # Enable check_mode and recreate
+        self.mock_module.check_mode = True
+        self.mock_module.params['recreate'] = True
+
+        # Mock LibvirtWrapper - VM exists and is active
+        mock_virt_conn = mock.Mock()
+        mock_vm = mock.Mock()
+        mock_vm.isActive.return_value = True
+        mock_virt_conn.find_vm.return_value = mock_vm
+        mock_libvirt_wrapper_class.return_value = mock_virt_conn
+
+        # Mock VirtInstallTool
+        mock_virt_install = mock.Mock()
+        mock_virt_install.execute.return_value = (True, VIRT_SUCCESS, {})
+        mock_virt_install_class.return_value = mock_virt_install
+
+        # Mock BaseImageOperator
+        mock_operator = mock.Mock()
+        mock_operator.validate_checksum.return_value = True
+        mock_operator.build_system_disk.return_value = {
+            'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_base_image_operator_class.return_value = mock_operator
+
+        # Execute core function
+        rc, result = core(self.mock_module)
+
+        # In check_mode, VM should NOT be destroyed or undefined
+        mock_virt_conn.destroy.assert_not_called()
+        mock_virt_conn.undefine.assert_not_called()
+
+        # But virt-install should be called with dryrun=True
+        mock_virt_install.execute.assert_called_once_with(dryrun=True, wait_timeout=None)
+
+        # Should still return success
+        self.assertEqual(rc, VIRT_SUCCESS)
+        self.assertTrue(result['changed'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/unit/modules/test_virt_install.py
+++ b/tests/unit/modules/test_virt_install.py
@@ -2293,4 +2293,4 @@ class TestCoreFunction(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
##### SUMMARY

This PR introduces a new virt_cloud_instance module that enables users to provision virtual machines from pre-built cloud images with cloud-init support. This addresses the need for a streamlined way to create VMs using modern cloud images rather than installing from scratch.

The following changes are included in this PR,
- Introduce virt_cloud_instance module to create and customize virtual machines using pre-built cloud images with cloud-init support
- Include qemu utilities for image format conversion and resizing
- Update documentation fragments for virt-install options

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
`virt_cloud_instance`

##### ADDITIONAL INFORMATION
Example with local base image
```yaml
tasks:
    - name: Create basic cloud instance from local image
      community.libvirt.virt_cloud_instance:
        name: "test-cloud-basic"
        state: present
        recreate: true
        base_image: "/srv/cloudimg/noble-server-cloudimg-amd64.img"
        memory: 4096
        vcpus: 2
        disks:
          - path: "/var/lib/libvirt/images/test-cloud-basic.qcow2"
            size: 50
            format: qcow2
            bus: virtio
        osinfo:
          name: ubuntu24.04
        networks:
          - bridge: br0
            model:
              type: virtio
        graphics:
          type: vnc
        cloud_init:
          user_data: |
            #cloud-config
            users:
              - name: testuser
                sudo: ALL=(ALL) NOPASSWD:ALL
                shell: /bin/bash
            chpasswd:
              expire: false
              list:
                - testuser:Password123!
            ssh_pwauth: true
          network_config: |
            version: 2
            ethernets:
              enp1s0:
                dhcp4: false
                optional: true
                addresses:
                - 192.168.30.74/24
                gateway4: 192.168.30.1
                nameservers:
                  addresses:
                  - 192.168.30.1
        wait_for_cloud_init_reboot: true
```

Example with remote image URL
```yaml
tasks:
    - name: Create cloud instance with remote image download
      community.libvirt.virt_cloud_instance:
        name: "test-cloud-remote"
        state: present
        recreate: true
        base_image: "[{{ cloud_image_url }}](https://mirrors.tuna.tsinghua.edu.cn/ubuntu-cloud-images/noble/current/noble-server-cloudimg-amd64.img)"
        image_cache_dir: "/srv/cloudimg-cache"
        image_checksum: "sha256:https://mirrors.tuna.tsinghua.edu.cn/ubuntu-cloud-images/noble/current/SHA256SUMS"
        force_pull: false
        url_timeout: 300
        memory: 4096
        vcpus: 2
        disks:
          - path: "/var/lib/libvirt/images/test-cloud-remote-system.qcow2"
            size: 50
            format: qcow2
            bus: virtio
            cache: none
            driver:
              discard: unmap
              io: native
        osinfo:
          name: ubuntu24.04
        networks:
          - bridge: br0
            model:
              type: virtio
        graphics:
          type: vnc
        cloud_init:
          user_data: |
            #cloud-config
            users:
              - name: testuser
                sudo: ALL=(ALL) NOPASSWD:ALL
                shell: /bin/bash
            chpasswd:
              expire: false
              list:
                - testuser:Password123!
            ssh_pwauth: true
          network_config: |
            version: 2
            ethernets:
              enp1s0:
                dhcp4: false
                optional: true
                addresses:
                - 192.168.30.75/24
                gateway4: 192.168.30.1
                nameservers:
                  addresses:
                  - 192.168.30.1
```