### PR TITLE
Add virt_volume return key/value pairs for Type, Capacity and Allocation

### DIFF
--- a/changelogs/fragments/212_fix_list_volumes.yml
+++ b/changelogs/fragments/212_fix_list_volumes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - virt_volume - New return key/value pairs 'Type', 'Capacity' and 'Allocation' were added to command 'list_volumes' (https://github.com/ansible-collections/community.libvirt/issues/187)

--- a/plugins/module_utils/constants.py
+++ b/plugins/module_utils/constants.py
@@ -1,0 +1,15 @@
+# (c) 2025, Bernhard Turmann <bernhard@turmann.eu>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+VOLUME_TYPE_INFO_MAP = {
+    0: "file",
+    1: "block",
+    2: "dir",
+    3: "network",
+    4: "netdir",
+    5: "ploop"
+}

--- a/plugins/modules/virt_volume.py
+++ b/plugins/modules/virt_volume.py
@@ -152,6 +152,25 @@ EXAMPLES = '''
   register: r__virt_volume__create_cidata_cdrom
 '''
 
+RETURN = r"""
+type:
+  description: When I(command=list_volumes) returns the type of the volume based on the underlying type of the pool.
+  returned: success
+  type: str
+  sample: "file"
+capacity:
+  description: When I(command=list_volumes) returns the total capacity of the volume in bytes.
+  returned: success
+  type: int
+  sample: "8589934592"
+allocation:
+  description: When I(command=list_volumes) returns the current allocated size of the volume in bytes.
+  returned: success
+  type: int
+  sample: "2740523008"
+"""
+
+from ansible_collections.community.libvirt.plugins.module_utils.constants import VOLUME_TYPE_INFO_MAP
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 import traceback
 
@@ -347,7 +366,14 @@ class LibvirtConnection(object):
         """ List all volumes in the storage pool (https://libvirt.org/html/libvirt-libvirt-storage.html#virStoragePoolListAllVolumes) """
         results = []
         for entry in self.pool_ptr.listAllVolumes():
-            results.append({'name': entry.name(), 'path': entry.path(), 'key': entry.key(), 'XMLDesc': entry.XMLDesc(0), 'info': entry.info()})
+            results.append({'name': entry.name(),
+                            'path': entry.path(),
+                            'key': entry.key(),
+                            'XMLDesc': entry.XMLDesc(0),
+                            'capacity': entry.info()[1],
+                            'allocation': entry.info()[2],
+                            'type': VOLUME_TYPE_INFO_MAP.get(entry.info()[0], 'unknown'),
+                            'info': entry.info()})
         return {'changed': False, 'res': results}
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #212

Currently, 'virt_volume' command 'list_volumes' is returning a key 'info' which contains a simple list of several numbers. For someone unfamiliar with the libvirt internals the meaning of these values in 'info' are rather unclear.

This PR takes the list of numbers and returns them in following additional key/value pairs:

- 'Type': type of the volume as string (taken from a map as constant)
- 'Capacity': total size of the volume in bytes as integer
- 'Allocation': current allocated size of the volume in bytes as integer

Sources:
- https://libvirt.org/html/libvirt-libvirt-storage.html#virStorageVolInfo
- https://libvirt.org/html/libvirt-libvirt-storage.html#virStorageVolType

Create a new module_util to hold constants with the future goal to share code more easily between modules.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
virt_volume

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Example:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# ansible -i hosts.ini host99 -b -m community.libvirt.virt_volume -a "command=list_volumes pool=default"
host99 | SUCCESS => {
    "changed": false,
    "list_volumes": [
        {
            "XMLDesc": "<volume type='file'>\n  <name>test03.qcow2</name>\n  <key>/var/lib/libvirt/images/test03.qcow2</key>\n  <capacity unit='bytes'>8589934592</capacity>\n  <allocation unit='bytes'>2740523008</allocation>\n  <physical unit='bytes'>2825256960</physical>\n  <target>\n    <path>/var/lib/libvirt/images/test03.qcow2</path>\n    <format type='qcow2'/>\n    <permissions>\n      <mode>0600</mode>\n      <owner>64055</owner>\n      <group>64055</group>\n    </permissions>\n    <timestamps>\n      <atime>1755766748.590299455</atime>\n      <mtime>1755768613.119877495</mtime>\n      <ctime>1755768613.119877495</ctime>\n      <btime>0</btime>\n    </timestamps>\n    <compat>1.1</compat>\n    <clusterSize unit='B'>65536</clusterSize>\n    <features/>\n  </target>\n</volume>\n",
            "allocation": 2740523008,
            "capacity": 8589934592,
            "info": [
                0,
                8589934592,
                2740523008
            ],
            "key": "/var/lib/libvirt/images/test03.qcow2",
            "name": "test03.qcow2",
            "path": "/var/lib/libvirt/images/test03.qcow2",
            "type": "file"
        }
    ]
}
```

**Note:**
In order to avoid a sudden breaking change, the key 'info' is still retained. But it should be deprecated and removed later.

