### PR TITLE
Add an example of how to create a volume from a template

### DIFF
--- a/plugins/modules/virt_volume.py
+++ b/plugins/modules/virt_volume.py
@@ -97,6 +97,12 @@ EXAMPLES = '''
       </target>
       </volume>
 
+- name: Create a volume from a template
+  community.libvirt.virt_volume:
+    pool: default
+    xml: "{{ lookup('ansible.builtin.template', 'volume-template.xml.j2') }}"
+    state: present
+
 - name: List volumes in default pool
   community.libvirt.virt_volume:
     pool: default


### PR DESCRIPTION
##### SUMMARY
Add an example of how to create a volume from a template

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
virt_volume

##### ADDITIONAL INFORMATION
The current examples only showed how to do it providing the xml content inline, so I think that using a template is more Ansible-like.
