### PR TITLE
Enhance networks.source parameter for virt_install and virt_cloud_instance modules

### DIFF
--- a/changelogs/fragments/221-networks-source-opts.yaml
+++ b/changelogs/fragments/221-networks-source-opts.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+  - virt_install - added new networks.source_opts parameter to provide additional macvtap options.
+  - virt_cloud_instance - added new networks.source_opts parameter to provide additional macvtap options.
+  - virt_install - enhanced networks.source parameter to support both string and dictionary inputs.
+  - virt_cloud_instance - enhanced networks.source parameter to support both string and dictionary inputs.

--- a/plugins/doc_fragments/virt_install.py
+++ b/plugins/doc_fragments/virt_install.py
@@ -1301,9 +1301,17 @@ options:
           - Specify the interface ROM BIOS configuration
           - The dictionary contains key/value pairs that define individual properties.
       source:
+        type: raw
+        description:
+          - Specify the source host interface.
+          - Can be either a string of IFACE name or a dictionary with detailed configuration.
+          - When provided as a string, use I(source_opts) to specify additional source properties.
+          - "Example as string: V(bond0)"
+          - "Example with source_opts: I(source=bond0) and I(source_opts={mode: bridge})"
+      source_opts:
         type: dict
         description:
-          - Specify the details of the source network interface.
+          - Additional options for the direct attached macvtap interface.
           - The dictionary contains key/value pairs that define individual properties.
       target:
         type: dict

--- a/plugins/module_utils/virt_install.py
+++ b/plugins/module_utils/virt_install.py
@@ -524,6 +524,7 @@ class VirtInstallTool(object):
             network_mapping = {
                 'trust_guest_rx_filters': ('trustGuestRxFilters', None),
                 'state': ('link.state', None),
+                'source_opts': ('source', None),
             }
             for network in network_param:
                 self._add_parameter('--network',
@@ -774,6 +775,19 @@ class VirtInstallTool(object):
                         self.module.fail_json(
                             msg="cloud_init.{} must be a string or dictionary, got {}".format(
                                 param_name, type(param_value).__name__))
+
+        if self.params.get('networks') is not None:
+            for idx, network in enumerate(self.params['networks']):
+                if network.get('source') is not None:
+                    source_value = network['source']
+                    if not isinstance(source_value, (str, dict)):
+                        self.module.fail_json(
+                            msg="networks[{}].source must be a string or dictionary, got {}".format(
+                                idx, type(source_value).__name__))
+
+                    if isinstance(source_value, dict) and network.get('source_opts') is not None:
+                        self.module.fail_json(
+                            msg="networks[{}].source and networks[{}].source_opts cannot both be dictionaries.")
 
     def _build_command(self):
         """Build the complete virt-install command"""
@@ -1491,7 +1505,8 @@ def get_networks_args():
                 network=dict(type='str'),
                 bridge=dict(type='str'),
                 hostdev=dict(type='str'),
-                source=dict(type='dict'),
+                source=dict(type='raw'),
+                source_opts=dict(type='dict'),
                 mac=dict(type='dict', options=dict(address=dict(type='str'))),
                 mtu=dict(type='dict'),
                 state=dict(type='dict'),


### PR DESCRIPTION
##### SUMMARY

This PR enhances the networks.source and networks.source_opts parameters for virt_install and virt_cloud_instance modules, including:
- Add new networks.source_opts parameter to provide additional macvtap options.
- Enhance networks.source parameter to support both string (macvtap host interface) and dictionary inputs.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

`virt_install`
`virt_cloud_instance`

##### ADDITIONAL INFORMATION

Task snippet in the test playbook
```yaml
  - name: Create OpenStack controller virtual machine
    community.libvirt.virt_cloud_instance:
      name: '{{ item }}'
      state: present
      base_image: '{{ openstack_node_base_image }}'
      image_cache_dir: '{{ cloudimg_cache_dir }}'
      image_checksum: '{{ openstack_node_base_image_checksum }}'
      force_pull: false
      force_disk: true
      url_timeout: 600
      memory: 32768
      memory_opts:
        current_memory: 16384
      vcpus: 4
      osinfo:
        name: '{{ openstack_node_osname }}'
      graphics:
        type: vnc
      iothreads: 1
      disks:
        - path: /srv/kvm/images/{{ item }}.qcow2
          size: 100
          bus: virtio
          cache: none
          format: qcow2
          driver:
            io: native
            discard: unmap
            detect_zeroes: unmap
      networks:
        - bridge: br0
          model:
            type: virtio
        - type: direct
          source: bond0
          source_opts:
            mode: bridge
          model:
            type: virtio
      cloud_init:
        meta_data: |
          local-hostname: {{ item }}
        user_data: |
          #cloud-config
          users:
            - name: sysadm
              sudo: ALL=(ALL) NOPASSWD:ALL
              shell: /bin/bash
              ssh_authorized_keys:
                - "{{ openstack_node_ssh_key }}"
          ssh_pwauth: false
          apt:
            preserve_sources_list: false
            primary:
              - arches: [default]
                uri: http://mirrors.ustc.edu.cn/ubuntu/
            security:
              - arches: [default]
                uri: http://mirrors.ustc.edu.cn/ubuntu/
        network_config: |
          version: 2
          ethernets:
            enp1s0:
              dhcp4: false
              addresses:
              - {{ hostvars[item].ansible_host }}/24
              routes:
              - to: default
                via: 192.168.10.254
              nameservers:
                addresses:
                - 192.168.10.1
                - 192.168.100.1
      wait_for_cloud_init_reboot: true
    loop: "{{ groups['openstack_controllers'] }}"
```
