### PR TITLE
ci: add 2.19 back into the test matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -177,6 +177,7 @@ stages:
     dependsOn:
       - Ansible_devel
       - Ansible_2_20
+      - Ansible_2_19
       - Ansible_2_18
       - Ansible_2_17
       - Docker_devel

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,2 +1,6 @@
-tests/utils/shippable/timing.py shebang
+plugins/connection/libvirt_qemu.py pylint:ansible-bad-import-from
+plugins/inventory/libvirt.py pylint:ansible-bad-import-from
 tests/unit/compat/builtins.py pylint:unused-import
+tests/unit/mock/procenv.py pylint:ansible-bad-import-from
+tests/unit/mock/yaml_helper.py pylint:ansible-bad-import-from
+tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
2.19 test was accidentally removed in #220, this restores it.