### PR TITLE
Add new force_disk parameter for cloud_virtual_instance module

### DIFF
--- a/plugins/doc_fragments/virt_install.py
+++ b/plugins/doc_fragments/virt_install.py
@@ -1313,6 +1313,7 @@ options:
         description:
           - Additional options for the direct attached macvtap interface.
           - The dictionary contains key/value pairs that define individual properties.
+        version_added: '2.1.0'
       target:
         type: dict
         description:


### PR DESCRIPTION
##### SUMMARY

This PR adds a new force_disk parameter to force deletion and recreation of existing disk files for virt_cloud_instance module. It could be useful to repetitive execution after a failed task.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

`virt_cloud_instance`

##### ADDITIONAL INFORMATION

Task snippet in the test playbook
```yaml
  - name: Create OpenStack controller virtual machine
    community.libvirt.virt_cloud_instance:
      name: '{{ item }}'
      state: present
      base_image: '{{ openstack_node_base_image }}'
      image_cache_dir: '{{ cloudimg_cache_dir }}'
      image_checksum: '{{ openstack_node_base_image_checksum }}'
      force_pull: false
      force_disk: true
      url_timeout: 600
      memory: 32768
      memory_opts:
        current_memory: 16384
      vcpus: 4
      osinfo:
        name: '{{ openstack_node_osname }}'
      graphics:
        type: vnc
      iothreads: 1
      disks:
        - path: /srv/kvm/images/{{ item }}.qcow2
          size: 100
          bus: virtio
          cache: none
          format: qcow2
          driver:
            io: native
            discard: unmap
            detect_zeroes: unmap
      networks:
        - bridge: br0
          model:
            type: virtio
        - type: direct
          source: bond0
          source_opts:
            mode: bridge
          model:
            type: virtio
      cloud_init:
        meta_data: |
          local-hostname: {{ item }}
        user_data: |
          #cloud-config
          users:
            - name: sysadm
              sudo: ALL=(ALL) NOPASSWD:ALL
              shell: /bin/bash
              ssh_authorized_keys:
                - "{{ openstack_node_ssh_key }}"
          ssh_pwauth: false
          apt:
            preserve_sources_list: false
            primary:
              - arches: [default]
                uri: http://mirrors.ustc.edu.cn/ubuntu/
            security:
              - arches: [default]
                uri: http://mirrors.ustc.edu.cn/ubuntu/
        network_config: |
          version: 2
          ethernets:
            enp1s0:
              dhcp4: false
              addresses:
              - {{ hostvars[item].ansible_host }}/24
              routes:
              - to: default
                via: 192.168.10.254
              nameservers:
                addresses:
                - 192.168.10.1
                - 192.168.100.1
      wait_for_cloud_init_reboot: true
    loop: "{{ groups['openstack_controllers'] }}"
```