### PR TITLE
Enhance virt_install and virt_cloud_instance to support primary value attribute

### DIFF
--- a/changelogs/fragments/221-networks-source-opts.yaml
+++ b/changelogs/fragments/221-networks-source-opts.yaml
@@ -1,5 +1,0 @@
-minor_changes:
-  - virt_install - added new networks.source_opts parameter to provide additional macvtap options.
-  - virt_cloud_instance - added new networks.source_opts parameter to provide additional macvtap options.
-  - virt_install - enhanced networks.source parameter to support both string and dictionary inputs.
-  - virt_cloud_instance - enhanced networks.source parameter to support both string and dictionary inputs.

--- a/changelogs/fragments/225-primary-value-support.yml
+++ b/changelogs/fragments/225-primary-value-support.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - virt_install - added support for primary value attribute (_value or value) in dynamic dict options that require a primary value alongside additional attributes.
+  - virt_cloud_instance - added support for primary value attribute (_value or value) in dynamic dict options that require a primary value alongside additional attributes.

--- a/plugins/doc_fragments/virt_install.py
+++ b/plugins/doc_fragments/virt_install.py
@@ -1301,19 +1301,12 @@ options:
           - Specify the interface ROM BIOS configuration
           - The dictionary contains key/value pairs that define individual properties.
       source:
-        type: raw
-        description:
-          - Specify the source host interface.
-          - Can be either a string of IFACE name or a dictionary with detailed configuration.
-          - When provided as a string, use I(source_opts) to specify additional source properties.
-          - "Example as string: V(bond0)"
-          - "Example with source_opts: I(source=bond0) and I(source_opts={mode: bridge})"
-      source_opts:
         type: dict
         description:
-          - Additional options for the direct attached macvtap interface.
+          - Specify the details of the direct attached macvtap interface.
           - The dictionary contains key/value pairs that define individual properties.
-        version_added: '2.1.0'
+          - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+          - "Example: I(source={value: bond0, mode: bridge})"
       target:
         type: dict
         description:
@@ -1391,6 +1384,7 @@ options:
       - Attach a controller device to the guest.
       - The dictionary contains key/value pairs that define individual controller properties.
       - Examples include I(type=usb,model=none) to disable USB, or I(type=scsi,model=virtio-scsi) for VirtIO SCSI.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   controller_devices:
     type: list
     elements: dict
@@ -1406,6 +1400,7 @@ options:
       - Attach an input device to the guest.
       - Input device types include mouse, tablet, or keyboard.
       - The dictionary contains key/value pairs that define individual input device properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   input_devices:
     type: list
     elements: dict
@@ -1420,6 +1415,7 @@ options:
     description:
       - Attach a physical host device to the guest.
       - The dictionary contains key/value pairs that define individual host device properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   host_devices:
     type: list
     elements: dict
@@ -1435,6 +1431,7 @@ options:
       - Attach a virtual audio device to the guest.
       - The dictionary contains key/value pairs that define individual sound device properties.
       - Common properties include I(model) (e.g. V(ich6), V(ich9), V(ac97)).
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   sound_devices:
     type: list
     elements: dict
@@ -1449,6 +1446,7 @@ options:
     description:
       - Configure host audio output for the guest's sound hardware.
       - The dictionary contains key/value pairs that define individual audio backend properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   audio_devices:
     type: list
     elements: dict
@@ -1463,6 +1461,7 @@ options:
     description:
       - Attach a virtual hardware watchdog device to the guest.
       - The dictionary contains key/value pairs that define individual watchdog properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   watchdog_devices:
     type: list
     elements: dict
@@ -1477,6 +1476,7 @@ options:
     description:
       - Attach a serial device to the guest with various redirection options.
       - The dictionary contains key/value pairs that define individual serial device properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   serial_devices:
     type: list
     elements: dict
@@ -1491,6 +1491,7 @@ options:
     description:
       - Attach a parallel device to the guest.
       - The dictionary contains key/value pairs that define individual parallel device properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   parallel_devices:
     type: list
     elements: dict
@@ -1505,6 +1506,7 @@ options:
     description:
       - Attach a communication channel device to connect the guest and host machine.
       - The dictionary contains key/value pairs that define individual channel properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   channel_devices:
     type: list
     elements: dict
@@ -1520,6 +1522,7 @@ options:
       - Connect a text console between the guest and host.
       - The dictionary contains key/value pairs that define individual console properties.
       - Common properties include I(type) and I(target) for different console types.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   console_devices:
     type: list
     elements: dict
@@ -1534,6 +1537,7 @@ options:
     description:
       - Specify what video device model will be attached to the guest.
       - The dictionary contains key/value pairs that define individual video device properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   video_devices:
     type: list
     elements: dict
@@ -1548,6 +1552,7 @@ options:
     description:
       - Configure a virtual smartcard device.
       - The dictionary contains key/value pairs that define individual smartcard properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   smartcard_devices:
     type: list
     elements: dict
@@ -1563,6 +1568,7 @@ options:
       - Add a redirected device for USB or other device redirection.
       - The dictionary contains key/value pairs that define individual redirection properties.
       - Common properties include I(bus=usb), I(type=tcp) or I(type=spicevmc).
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   redirected_devices:
     type: list
     elements: dict
@@ -1578,6 +1584,7 @@ options:
       - Attach a virtual memory balloon device to the guest.
       - The dictionary contains key/value pairs that define individual memory balloon properties.
       - Common properties include I(model) (e.g. V(virtio), V(xen)).
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   memballoon_devices:
     type: list
     elements: dict
@@ -1592,6 +1599,7 @@ options:
     description:
       - Configure a virtual TPM (Trusted Platform Module) device.
       - The dictionary contains key/value pairs that define individual TPM properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   tpm_devices:
     type: list
     elements: dict
@@ -1606,6 +1614,7 @@ options:
     description:
       - Configure a virtual random number generator (RNG) device.
       - The dictionary contains key/value pairs that define individual RNG properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   rng_devices:
     type: list
     elements: dict
@@ -1620,6 +1629,7 @@ options:
     description:
       - Attach a panic notifier device to the guest.
       - The dictionary contains key/value pairs that define individual panic device properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   panic_devices:
     type: list
     elements: dict
@@ -1634,6 +1644,7 @@ options:
     description:
       - Attach a shared memory device to the guest.
       - The dictionary contains key/value pairs that define individual shared memory properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   shmem_devices:
     type: list
     elements: dict
@@ -1648,6 +1659,7 @@ options:
     description:
       - Configure a vsock host/guest interface.
       - The dictionary contains key/value pairs that define individual vsock properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   vsock_devices:
     type: list
     elements: dict
@@ -1662,6 +1674,7 @@ options:
     description:
       - Add an IOMMU device to the guest.
       - The dictionary contains key/value pairs that define individual IOMMU properties.
+      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
   iommu_devices:
     type: list
     elements: dict

--- a/plugins/modules/virt_install.py
+++ b/plugins/modules/virt_install.py
@@ -283,6 +283,20 @@ EXAMPLES = """
     import: true
 
 
+# VM with PCI passthrough for a network device
+- name: Create VM with PCI network passthrough
+  community.libvirt.virt_install:
+    name: passthrough-vm
+    memory: 4096
+    vcpus: 4
+    disks:
+      - size: 30
+    osinfo:
+      name: ubuntu20.04
+    import: true
+    host_devices:
+      - value: "81:00.0"
+
 # Recreate existing VM
 - name: Recreate existing VM with new configuration
   community.libvirt.virt_install:


### PR DESCRIPTION
##### SUMMARY

This PR enhances the virt_install and virt_cloud_instance modules by adding support for a special primary value attribute (_value or value) in command line options. This feature is essential for properly handling virt-install device options where a primary value must be specified alongside additional attributes.

Many virt-install device options (like --hostdev, --watchdog, --serial, etc.) follow the pattern --option primary_value,attr1=val1,attr2=val2. Without the ability to specify a primary value, these options cannot be fully configured. The hostdev issue mentioned in #222 can be resolved by this PR.

The _dict2options function has been updated to prioritize _value over value and handle formatting correctly. This enhancement also allows simplification of the networks.source_opts parameter that was added in a previous PR (#221), as it can now be handled more elegantly using the primary value attribute. For example, `--network source=bond0,source.mode=bridge` can be defined as "source: {value: bond0, mode: bridge}" with the primary value for the nested `networks.source` dict. So, the previous PR #221 can be reverted safely before creating releaes 2.1.0. 

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
`virt_install`
`virt_cloud_instance`

##### ADDITIONAL INFORMATION

Task snippet in the test playbook.
```yaml
  - name: Create OpenStack controller virtual machine
    community.libvirt.virt_cloud_instance:
      name: '{{ item }}'
      state: present
      base_image: '{{ openstack_node_base_image }}'
      image_cache_dir: '{{ cloudimg_cache_dir }}'
      image_checksum: '{{ openstack_node_base_image_checksum }}'
      force_pull: false
      force_disk: true
      url_timeout: 600
      memory: 32768
      memory_opts:
        current_memory: 16384
      vcpus: 4
      osinfo:
        name: '{{ openstack_node_osname }}'
      graphics:
        type: vnc
      iothreads: 1
      disks:
        - path: /srv/kvm/images/{{ item }}.qcow2
          size: 100
          bus: virtio
          cache: none
          format: qcow2
          driver:
            io: native
            discard: unmap
            detect_zeroes: unmap
      networks:
        - bridge: br0
          model:
            type: virtio
      hostdev:
        value: "81:00.0"
      cloud_init:
        meta_data: |
          local-hostname: {{ item }}
        user_data: |
          #cloud-config
          users:
            - name: sysadm
              sudo: ALL=(ALL) NOPASSWD:ALL
              shell: /bin/bash
              ssh_authorized_keys:
                - "{{ openstack_node_ssh_key }}"
          ssh_pwauth: false
          apt:
            preserve_sources_list: false
            primary:
              - arches: [default]
                uri: http://mirrors.ustc.edu.cn/ubuntu/
            security:
              - arches: [default]
                uri: http://mirrors.ustc.edu.cn/ubuntu/
        network_config: |
          version: 2
          ethernets:
            enp1s0:
              dhcp4: false
              addresses:
              - {{ hostvars[item].ansible_host }}/24
              routes:
              - to: default
                via: 192.168.10.254
              nameservers:
                addresses:
                - 192.168.10.1
                - 192.168.100.1
      wait_for_cloud_init_reboot: true
    loop: "{{ groups['openstack_controllers'] }}"
```