### PR TITLE
fix: add support for memoryBacking source type configuration (#228)

### DIFF
--- a/changelogs/fragments/230-memorybacking-memfd-support.yml
+++ b/changelogs/fragments/230-memorybacking-memfd-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - virt_install - added support for memoryBacking source type configuration, including memfd for shared memory (https://github.com/ansible-collections/community.libvirt/issues/228).

--- a/plugins/doc_fragments/virt_install.py
+++ b/plugins/doc_fragments/virt_install.py
@@ -70,6 +70,17 @@ options:
         type: bool
         description:
           - Memory pages will be locked in host's memory and will not be swapped out.
+      source:
+        type: dict
+        description:
+          - Configure the source of memory backing.
+        version_added: '2.1.0'
+        suboptions:
+          type:
+            type: str
+            choices: [ anonymous, file, memfd ]
+            description:
+              - The type of memory backing source.
       access:
         type: dict
         description:

--- a/plugins/module_utils/virt_install.py
+++ b/plugins/module_utils/virt_install.py
@@ -273,6 +273,7 @@ class VirtInstallTool(object):
                 'hugepage_specs': ('hugepages.page', {
                     'page_size': ('size', None),
                 }),
+                'source': ('source', None),
             }
             self._add_parameter('--memorybacking',
                                 dict_value=self.params['memorybacking'],
@@ -893,6 +894,14 @@ def get_memorybacking_args():
                 ),
                 nosharepages=dict(type='bool'),
                 locked=dict(type='bool'),
+                source=dict(
+                    type='dict',
+                    options=dict(
+                        type=dict(
+                            type='str',
+                            choices=['anonymous', 'file', 'memfd']),
+                    ),
+                ),
                 access=dict(
                     type='dict',
                     options=dict(

--- a/tests/unit/module_utils/test_virt_install.py
+++ b/tests/unit/module_utils/test_virt_install.py
@@ -890,6 +890,33 @@ class TestBuildCommand(unittest.TestCase):
         self.assertIn('hugepages.page0.size=2048', memorybacking_cmdline)
         self.assertIn('hugepages.page0.nodeset=0-1', memorybacking_cmdline)
 
+    def test_memorybacking_with_memfd_source(self):
+        """Test memorybacking parameter with memfd source"""
+        self.mock_module.params = {
+            'name': 'test-vm',
+            'memory': 4096,
+            'memorybacking': {
+                'source': {
+                    'type': 'memfd'
+                },
+                'access': {
+                    'mode': 'shared'
+                }
+            }
+        }
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install._build_command()
+
+        try:
+            idx = self.virt_install.command_argv.index('--memorybacking')
+            memorybacking_cmdline = self.virt_install.command_argv[idx + 1]
+        except (ValueError, IndexError):
+            memorybacking_cmdline = None
+
+        self.assertIsNotNone(memorybacking_cmdline)
+        self.assertIn('source.type=memfd', memorybacking_cmdline)
+        self.assertIn('access.mode=shared', memorybacking_cmdline)
+
     def test_vcpus_configuration(self):
         """Test vcpus parameter with options"""
         self.mock_module.params = {


### PR DESCRIPTION
##### SUMMARY

This PR addresses issue #228 by enhancing the `community.libvirt.virt_install` module to support `memoryBacking` with a `source type='memfd'`. This fix allows users to enable shared memory for virtual machines, aligning the module's capabilities with configurations available in tools like `virt-manager`.

Previously, the `virt_install` module lacked the ability to specify the `memfd` source type for memory backing. This fix introduces a new 'source' parameter in the memoryBacking configuration to allow specifying the type of memory backing (`anonymous`, `file`, `memfd`).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`virt_install`

##### ADDITIONAL INFORMATION

**Usage Example:**

Users can now configure shared memory with `memfd` in their Ansible playbooks as follows:

```yaml
- name: Create VM with shared memory using memfd
  community.libvirt.virt_install:
    name: my-shared-memory-vm
    memory: 4096
    memorybacking:
      source:
        type: memfd
      access:
        mode: shared
    vcpus: 4
    disks:
      - size: 30
    osinfo:
      name: fedora39
    import: true
    networks:
      - network: default
```
