### PR TITLE
fix: virt_cloud_instance - add boot option support for UEFI (#232)

### DIFF
--- a/plugins/modules/virt_cloud_instance.py
+++ b/plugins/modules/virt_cloud_instance.py
@@ -135,6 +135,7 @@ extends_documentation_fragment:
     - community.libvirt.virt_install.options_clock
     - community.libvirt.virt_install.options_pm
     - community.libvirt.virt_install.options_launch_security
+    - community.libvirt.virt_install.options_boot
     - community.libvirt.virt_install.options_osinfo
     - community.libvirt.virt_install.options_disks
     - community.libvirt.virt_install.options_filesystems
@@ -742,6 +743,8 @@ def main():
     argument_spec.update(virtinst_util.get_clock_args())
     argument_spec.update(virtinst_util.get_pm_args())
     argument_spec.update(virtinst_util.get_launch_security_args())
+    # Boot options
+    argument_spec.update(virtinst_util.get_boot_args())
     # Guest OS options
     argument_spec.update(virtinst_util.get_osinfo_args())
     # Storage options


### PR DESCRIPTION
##### SUMMARY

This PR adds support for UEFI firmware configuration in the `virt_cloud_instance` module by enabling the `boot` and `boot_opts` parameters. Previously, VMs created with `virt_cloud_instance` were BIOS-only, with no way to specify UEFI firmware (unlike `virt_install` which already supported this). (Fixes #232)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`virt_cloud_instance`

##### ADDITIONAL INFORMATION
**Example usage (UEFI VM with virt_cloud_instance):**
```yaml
- name: Create UEFI-enabled cloud VM
  community.libvirt.virt_cloud_instance:
    name: uefi-test-vm
    base_image: /path/to/cloud-image.qcow2
    boot: uefi
    disks:
      - path: /var/lib/libvirt/images/uefi-vm.qcow2
        size: 20
        format: qcow2
    memory: 2048
    vcpus: 2
    networks:
      - network: default
    ...
``` 