### PR TITLE
feat: add commands return value for provisioning tools

### DIFF
--- a/changelogs/fragments/241-virt-install-commands.yml
+++ b/changelogs/fragments/241-virt-install-commands.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - virt_install - added commands return field to provide visibility into executed commands during VM provisioning.
+  - virt_cloud_instance - added commands return field to provide visibility into executed commands during VM provisioning.

--- a/plugins/module_utils/qemu.py
+++ b/plugins/module_utils/qemu.py
@@ -18,6 +18,11 @@ class QemuImgTool(object):
         self.warnings = []
         self._base_command = qemu_img_path if qemu_img_path is not None else 'qemu-img'
         self.command_argv = [self._base_command]
+        self._executed_commands = []
+
+    def get_commands(self):
+        """Return list of commands that have been executed."""
+        return self._executed_commands
 
     def _reset_command(self):
         """Reset command_argv to base command for new operation"""
@@ -73,6 +78,9 @@ class QemuImgTool(object):
 
         # Add output filename (must be last)
         self.command_argv.append(str(output_filename))
+
+        # Store the command for later retrieval
+        self._executed_commands.append(' '.join(self.command_argv))
 
         # Check if we're in check mode
         if self.module.check_mode:
@@ -158,6 +166,9 @@ class QemuImgTool(object):
 
         # Add size (must be last)
         self.command_argv.append(str(size))
+
+        # Store the command for later retrieval
+        self._executed_commands.append(' '.join(self.command_argv))
 
         # Check if we're in check mode
         if self.module.check_mode:

--- a/plugins/module_utils/virt_install.py
+++ b/plugins/module_utils/virt_install.py
@@ -171,12 +171,19 @@ class VirtInstallTool(object):
         self.warnings = []
         self._base_command = virtinst_path if virtinst_path is not None else 'virt-install'
         self.command_argv = [self._base_command]
+        self._display_argv = [self._base_command]
+        self._executed_commands = []
 
         self._vm_name = self.params.get('name')
+
+    def get_commands(self):
+        """Return list of commands that have been executed."""
+        return self._executed_commands
 
     def _reset_command(self):
         """Reset command_argv to base command for new operation"""
         self.command_argv = [self._base_command]
+        self._display_argv = [self._base_command]
 
     def _save_string_to_tempfile(self, content, suffix='.tmp'):
         fd, path = tempfile.mkstemp(dir=self.module.tmpdir,
@@ -192,36 +199,55 @@ class VirtInstallTool(object):
             flag,
             primary_value=None,
             dict_value=None,
-            dict_mapping=None):
-        """Add a command line option to virt-install command"""
+            dict_mapping=None,
+            no_log=False,
+            sanitized_dict_value=None):
+        """Add a command line option to virt-install command.
+
+        no_log=True redacts the entire argument value in the display command.
+        sanitized_dict_value replaces dict_value only in the display command,
+        allowing per-key redaction of no_log sub-fields.
+        """
+        display_dict_value = sanitized_dict_value if sanitized_dict_value is not None else dict_value
+
         if primary_value:
             if dict_value:
+                real_value = "{},{}".format(str(primary_value), _dict2options(dict_value, dict_mapping))
                 self.command_argv.append("{}".format(flag))
-                self.command_argv.append(
-                    "{},{}".format(
-                        str(primary_value),
-                        _dict2options(
-                            dict_value,
-                            dict_mapping)))
+                self.command_argv.append(real_value)
+                self._display_argv.append("{}".format(flag))
+                if no_log:
+                    self._display_argv.append("***")
+                else:
+                    self._display_argv.append(
+                        "{},{}".format(str(primary_value), _dict2options(display_dict_value, dict_mapping)))
                 return
             else:
                 self.command_argv.append("{}".format(flag))
                 self.command_argv.append("{}".format(str(primary_value)))
+                self._display_argv.append("{}".format(flag))
+                self._display_argv.append("***" if no_log else "{}".format(str(primary_value)))
                 return
         else:
             if dict_value:
                 self.command_argv.append("{}".format(flag))
-                self.command_argv.append("{}".format(
-                    _dict2options(dict_value, dict_mapping)))
+                self.command_argv.append("{}".format(_dict2options(dict_value, dict_mapping)))
+                self._display_argv.append("{}".format(flag))
+                if no_log:
+                    self._display_argv.append("***")
+                else:
+                    self._display_argv.append("{}".format(_dict2options(display_dict_value, dict_mapping)))
                 return
             else:
                 self.command_argv.append("{}".format(flag))
+                self._display_argv.append("{}".format(flag))
                 return
 
     def _add_flag_parameter(self, flag, value):
         """Add a flag command line option to virt-install command"""
         if value:
             self.command_argv.append("{}".format(flag))
+            self._display_argv.append("{}".format(flag))
             return
 
     def _get_param_combined_items(self, singular_key, plural_key):
@@ -402,7 +428,8 @@ class VirtInstallTool(object):
             }
             self._add_parameter('--keywrap',
                                 dict_value=self.params['keywrap'],
-                                dict_mapping=keywrap_mapping)
+                                dict_mapping=keywrap_mapping,
+                                no_log=True)
 
         if self.params.get('iothreads') is not None:
             iothreads_mapping = {
@@ -471,9 +498,13 @@ class VirtInstallTool(object):
                 'user_password_file': ('user-password-file', None),
                 'product_key': ('product-key', None),
             }
+            unattended_sanitized = self.params['unattended'].copy()
+            if unattended_sanitized.get('product_key') is not None:
+                unattended_sanitized['product_key'] = '***'
             self._add_parameter('--unattended',
                                 dict_value=self.params['unattended'],
-                                dict_mapping=unattended_mapping)
+                                dict_mapping=unattended_mapping,
+                                sanitized_dict_value=unattended_sanitized)
 
         if self.params.get('cloud_init') is not None:
             cloud_init_params = self.params['cloud_init'].copy()
@@ -508,9 +539,14 @@ class VirtInstallTool(object):
                     'clouduser-ssh-key',
                     None),
             }
+            cloud_init_sanitized = cloud_init_params.copy()
+            for _sensitive_key in ('root_ssh_key', 'clouduser_ssh_key'):
+                if cloud_init_sanitized.get(_sensitive_key) is not None:
+                    cloud_init_sanitized[_sensitive_key] = '***'
             self._add_parameter('--cloud-init',
                                 dict_value=cloud_init_params,
-                                dict_mapping=cloud_init_mapping)
+                                dict_mapping=cloud_init_mapping,
+                                sanitized_dict_value=cloud_init_sanitized)
 
         if self.params.get('boot') is not None:
             self._add_parameter('--boot', self.params['boot'],
@@ -827,6 +863,7 @@ class VirtInstallTool(object):
 
         # Always add --noautoconsole for non-interactive execution
         self.command_argv.append('--noautoconsole')
+        self._display_argv.append('--noautoconsole')
 
     def execute(self, dryrun=False, wait_timeout=None):
         changed = False
@@ -837,11 +874,17 @@ class VirtInstallTool(object):
 
         if dryrun:
             self.command_argv.append('--dry-run')
+            self._display_argv.append('--dry-run')
 
         if wait_timeout:
             wait_minutes = math.ceil(wait_timeout / 60.0)
             self.command_argv.append('--wait')
             self.command_argv.append(str(wait_minutes))
+            self._display_argv.append('--wait')
+            self._display_argv.append(str(wait_minutes))
+
+        # Store the sanitized command for later retrieval
+        self._executed_commands.append(' '.join(self._display_argv))
 
         # Execute the command
         rc, stdout, stderr = self.module.run_command(

--- a/plugins/modules/virt_cloud_instance.py
+++ b/plugins/modules/virt_cloud_instance.py
@@ -280,6 +280,19 @@ base_image_path:
     type: str
     returned: success
     sample: "/srv/cloud-images/ubuntu-20.04-server-cloudimg-amd64.img"
+commands:
+    description:
+        - List of commands executed by this module during VM provisioning.
+        - Includes qemu-img commands for disk preparation and the virt-install command to create the VM.
+        - Only populated when a VM is created or recreated (V(state=present) and VM did not already exist, or V(recreate=true)).
+        - In check mode, the virt-install command includes the C(--dry-run) flag.
+    type: list
+    elements: str
+    returned: when a VM was created or recreated
+    version_added: "2.2.0"
+    sample:
+      - "qemu-img resize /var/lib/libvirt/images/test.qcow2 20G"
+      - "virt-install --name test-vm --memory 2048 --vcpus 2 --import --disk path=/var/lib/libvirt/images/test.qcow2"
 """
 
 
@@ -306,6 +319,11 @@ class BaseImageOperator(object):
         self.image_checksum = image_checksum
         self.base_image_path = None
         self.system_disk_path = None
+        self._executed_commands = []
+
+    def get_commands(self):
+        """Return list of commands that have been executed."""
+        return self._executed_commands
 
     def fetch_image(self, force_pull, timeout=None):
         """
@@ -466,6 +484,9 @@ class BaseImageOperator(object):
         Args:
             disk_param: Disk configuration dictionary
             force_disk: If True, remove existing disk file before creating new one
+
+        Returns:
+            dict: The system disk configuration
         """
         system_disk = self._resolve_system_disk(disk_param)
         disk_path = self.system_disk_path
@@ -530,6 +551,9 @@ class BaseImageOperator(object):
         if rc != 0:
             self.module.fail_json(
                 msg="Failed to resize system disk: %s" % stderr)
+
+        # Collect executed commands from qemuImgTool
+        self._executed_commands.extend(qemuImgTool.get_commands())
 
         for key in ['format', 'size']:
             if key in system_disk:
@@ -610,9 +634,10 @@ def core(module):
 
     result = dict(
         changed=False,
-        original_message="",
+        original_message="",  # TODO: Remove this unused return field in v3.0.0
         message="",
         base_image_path="",
+        commands=[],
     )
 
     virtConn = LibvirtWrapper(module)
@@ -654,6 +679,7 @@ def core(module):
 
         # Add base_image_path to result
         result['base_image_path'] = image_operator.base_image_path
+        result['commands'].extend(image_operator.get_commands())
 
         extra_user_data = None
         if wait_for_cloud_init_reboot and cloud_init_auto_reboot:
@@ -666,7 +692,7 @@ def core(module):
         # run virt-install to create new vm
         update_virtinst_params(module, virtInstall, system_disk, extra_user_data)
         changed, rc, extra_res = virtInstall.execute(dryrun=module.check_mode, wait_timeout=wait_timeout)
-        # result['virt_install_command'] = ' '.join(virtInstall.command_argv)
+        result['commands'].extend(virtInstall.get_commands())
         result['changed'] = changed
         result.update(extra_res)
 

--- a/plugins/modules/virt_install.py
+++ b/plugins/modules/virt_install.py
@@ -320,7 +320,18 @@ EXAMPLES = """
     state: absent
 """
 
-RETURN = r""" # """
+RETURN = r"""
+commands:
+    description:
+        - List of virt-install commands executed by this module.
+        - Only populated when a VM is created or recreated (V(state=present) and VM did not already exist, or V(recreate=true)).
+        - In check mode, the command includes the C(--dry-run) flag.
+    type: list
+    elements: str
+    returned: when a virt-install command was executed
+    version_added: "2.2.0"
+    sample: ["virt-install --name test-vm --memory 2048 --vcpus 2 --import --disk path=/var/lib/libvirt/images/test.qcow2"]
+"""
 
 from ansible_collections.community.libvirt.plugins.module_utils import virt_install as virtinst_util
 from ansible_collections.community.libvirt.plugins.module_utils.virt_install import (
@@ -340,8 +351,9 @@ def core(module):
 
     result = dict(
         changed=False,
-        orignal_message="",
+        original_message="",  # TODO: Remove this unused return field in v3.0.0
         message="",
+        commands=[],
     )
 
     virtConn = LibvirtWrapper(module)
@@ -369,6 +381,7 @@ def core(module):
         # run virt-install to create new vm
         changed, rc, extra_res = virtInstall.execute(dryrun=module.check_mode)
         result['changed'] = changed
+        result['commands'].extend(virtInstall.get_commands())
         result.update(extra_res)
 
         return rc, result

--- a/tests/unit/module_utils/test_virt_install.py
+++ b/tests/unit/module_utils/test_virt_install.py
@@ -684,6 +684,37 @@ class TestAddParameter(unittest.TestCase):
         self.assertIn("vcpus.vcpu1.id=1", test_arg)
         self.assertIn("vcpus.vcpu1.enabled=off", test_arg)
 
+    def test_add_parameter_with_no_log_masks_display_only(self):
+        """Test no_log masks only the display command value"""
+        self.virt_install._add_parameter('--secret', 'super-secret', no_log=True)
+        self.assertEqual(self.virt_install.command_argv[-2:], ["--secret", "super-secret"])
+        self.assertEqual(self.virt_install._display_argv[-2:], ["--secret", "***"])
+
+    def test_add_parameter_uses_sanitized_dict_value_for_display(self):
+        """Test sanitized_dict_value is used only for display output"""
+        dict_value = {
+            "product_key": "AAAAA-BBBBB-CCCCC-DDDDD-EEEEE",
+            "profile": "desktop"
+        }
+        sanitized_dict_value = {
+            "product_key": "***",
+            "profile": "desktop"
+        }
+        mapping = {
+            "product_key": ("product-key", None),
+            "profile": ("profile", None)
+        }
+
+        self.virt_install._add_parameter(
+            '--unattended',
+            dict_value=dict_value,
+            dict_mapping=mapping,
+            sanitized_dict_value=sanitized_dict_value)
+
+        self.assertIn('product-key=AAAAA-BBBBB-CCCCC-DDDDD-EEEEE', self.virt_install.command_argv[-1])
+        self.assertIn('product-key=***', self.virt_install._display_argv[-1])
+        self.assertIn('profile=desktop', self.virt_install._display_argv[-1])
+
     def test_add_flag_parameter_true(self):
         """Test adding a flag parameter"""
         self.virt_install._add_flag_parameter('--test', True)
@@ -1662,6 +1693,71 @@ class TestBuildCommand(unittest.TestCase):
             'product-key=XXXXX-XXXXX-XXXXX-XXXXX-XXXXX',
             unattended_arg)
 
+    def test_unattended_masks_product_key_in_display_command(self):
+        """Test unattended product key is masked in display argv"""
+        product_key = 'XXXXX-XXXXX-XXXXX-XXXXX-XXXXX'
+        self.mock_module.params = {
+            'name': 'test-vm',
+            'memory': 2048,
+            'unattended': {
+                'profile': 'desktop',
+                'product_key': product_key
+            }
+        }
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install._build_command()
+
+        real_arg = None
+        display_arg = None
+        for i, arg in enumerate(self.virt_install.command_argv):
+            if arg == '--unattended' and i + 1 < len(self.virt_install.command_argv):
+                real_arg = self.virt_install.command_argv[i + 1]
+                break
+        for i, arg in enumerate(self.virt_install._display_argv):
+            if arg == '--unattended' and i + 1 < len(self.virt_install._display_argv):
+                display_arg = self.virt_install._display_argv[i + 1]
+                break
+
+        self.assertIsNotNone(real_arg)
+        self.assertIsNotNone(display_arg)
+        self.assertIn('product-key={}'.format(product_key), real_arg)
+        self.assertIn('product-key=***', display_arg)
+        self.assertNotIn('product-key={}'.format(product_key), display_arg)
+
+    def test_cloud_init_masks_sensitive_keys_in_display_command(self):
+        """Test cloud-init SSH keys are masked in display argv"""
+        self.mock_module.params = {
+            'name': 'test-vm',
+            'memory': 2048,
+            'cloud_init': {
+                'root_password_generate': True,
+                'root_ssh_key': '/path/to/root.pub',
+                'clouduser_ssh_key': '/path/to/clouduser.pub'
+            }
+        }
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install._build_command()
+
+        real_arg = None
+        display_arg = None
+        for i, arg in enumerate(self.virt_install.command_argv):
+            if arg == '--cloud-init' and i + 1 < len(self.virt_install.command_argv):
+                real_arg = self.virt_install.command_argv[i + 1]
+                break
+        for i, arg in enumerate(self.virt_install._display_argv):
+            if arg == '--cloud-init' and i + 1 < len(self.virt_install._display_argv):
+                display_arg = self.virt_install._display_argv[i + 1]
+                break
+
+        self.assertIsNotNone(real_arg)
+        self.assertIsNotNone(display_arg)
+        self.assertIn('root-ssh-key=/path/to/root.pub', real_arg)
+        self.assertIn('clouduser-ssh-key=/path/to/clouduser.pub', real_arg)
+        self.assertIn('root-ssh-key=***', display_arg)
+        self.assertIn('clouduser-ssh-key=***', display_arg)
+        self.assertNotIn('/path/to/root.pub', display_arg)
+        self.assertNotIn('/path/to/clouduser.pub', display_arg)
+
     def test_virtualization_options(self):
         """Test virtualization-specific options"""
         self.mock_module.params = {
@@ -2540,6 +2636,25 @@ class TestVirtInstallToolExecute(unittest.TestCase):
         # Verify return types
         self.assertIsInstance(changed, bool)
         self.assertIsInstance(rc, int)
+
+    def test_execute_records_sanitized_command(self):
+        """Test get_commands() returns sanitized command string"""
+        product_key = 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEE'
+        self.mock_module.params.update({
+            'unattended': {
+                'profile': 'desktop',
+                'product_key': product_key
+            }
+        })
+        self.mock_module.run_command.return_value = (0, "Success", "")
+        self.virt_install = VirtInstallTool(self.mock_module)
+
+        self.virt_install.execute()
+
+        executed_commands = self.virt_install.get_commands()
+        self.assertEqual(len(executed_commands), 1)
+        self.assertIn('product-key=***', executed_commands[0])
+        self.assertNotIn(product_key, executed_commands[0])
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/test_virt_cloud_instance.py
+++ b/tests/unit/modules/test_virt_cloud_instance.py
@@ -545,6 +545,7 @@ class TestBaseImageOperatorBuildSystemDisk(unittest.TestCase):
             'virtual-size': 1073741824  # 1GB
         }, '')
         mock_qemu_instance.resize.return_value = (0, '', '')
+        mock_qemu_instance.get_commands.return_value = []
 
         disk_param = {
             'path': '/var/lib/libvirt/images/vm.qcow2',
@@ -714,6 +715,7 @@ class TestBaseImageOperatorBuildSystemDisk(unittest.TestCase):
             'virtual-size': 1073741824  # 1GB
         }, '')
         mock_qemu_instance.resize.return_value = (0, '', '')
+        mock_qemu_instance.get_commands.return_value = []
 
         disk_param = {
             'path': '/var/lib/libvirt/images/vm.qcow2',
@@ -917,6 +919,7 @@ class TestBaseImageOperatorCheckMode(unittest.TestCase):
             'virtual-size': 5 * 1024 * 1024 * 1024  # 5GB
         }, '')
         mock_qemu_tool.resize.return_value = (0, '', '')
+        mock_qemu_tool.get_commands.return_value = []
         mock_qemu_tool_class.return_value = mock_qemu_tool
 
         operator = BaseImageOperator(self.mock_module, '/path/to/image.qcow2')
@@ -1002,6 +1005,8 @@ class TestCore(unittest.TestCase):
         """Set up test fixtures"""
         self.mock_module = mock.Mock()
         self.mock_module.check_mode = False
+        # Mock run_command to return proper tuple for LibvirtConnection initialization
+        self.mock_module.run_command.return_value = (0, 'linux-kernel', '')
 
         # Default successful params
         self.mock_module.params = {
@@ -1041,6 +1046,7 @@ class TestCore(unittest.TestCase):
         mock_virt_install = mock.Mock()
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, {'some': 'data'})
+        mock_virt_install.get_commands.return_value = []
         mock_virt_install_class.return_value = mock_virt_install
 
         # Mock BaseImageOperator
@@ -1048,6 +1054,7 @@ class TestCore(unittest.TestCase):
         mock_operator.validate_checksum.return_value = True
         mock_operator.build_system_disk.return_value = {
             'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_operator.get_commands.return_value = []
         mock_base_image_operator_class.return_value = mock_operator
 
         # Execute core function
@@ -1134,6 +1141,7 @@ class TestCore(unittest.TestCase):
         # Mock VirtInstallTool
         mock_virt_install = mock.Mock()
         mock_virt_install.execute.return_value = (True, VIRT_SUCCESS, {})
+        mock_virt_install.get_commands.return_value = []
         mock_virt_install_class.return_value = mock_virt_install
 
         # Mock BaseImageOperator
@@ -1141,6 +1149,7 @@ class TestCore(unittest.TestCase):
         mock_operator.validate_checksum.return_value = True
         mock_operator.build_system_disk.return_value = {
             'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_operator.get_commands.return_value = []
         mock_base_image_operator_class.return_value = mock_operator
 
         # Execute core function
@@ -1185,6 +1194,7 @@ class TestCore(unittest.TestCase):
         # Mock VirtInstallTool
         mock_virt_install = mock.Mock()
         mock_virt_install.execute.return_value = (True, VIRT_SUCCESS, {})
+        mock_virt_install.get_commands.return_value = []
         mock_virt_install_class.return_value = mock_virt_install
 
         # Mock BaseImageOperator
@@ -1192,6 +1202,7 @@ class TestCore(unittest.TestCase):
         mock_operator.validate_checksum.return_value = True
         mock_operator.build_system_disk.return_value = {
             'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_operator.get_commands.return_value = []
         mock_base_image_operator_class.return_value = mock_operator
 
         # Execute core function
@@ -1270,6 +1281,7 @@ class TestCore(unittest.TestCase):
         # Mock BaseImageOperator - checksum validation fails
         mock_operator = mock.Mock()
         mock_operator.validate_checksum.return_value = False
+        mock_operator.get_commands.return_value = []
         mock_base_image_operator_class.return_value = mock_operator
 
         # Configure fail_json to raise exception (as it should in real code)
@@ -1328,6 +1340,7 @@ class TestCore(unittest.TestCase):
         # Mock VirtInstallTool
         mock_virt_install = mock.Mock()
         mock_virt_install.execute.return_value = (True, VIRT_SUCCESS, {})
+        mock_virt_install.get_commands.return_value = []
         mock_virt_install_class.return_value = mock_virt_install
 
         # Mock BaseImageOperator
@@ -1335,6 +1348,7 @@ class TestCore(unittest.TestCase):
         mock_operator.validate_checksum.return_value = True
         mock_operator.build_system_disk.return_value = {
             'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_operator.get_commands.return_value = []
         mock_base_image_operator_class.return_value = mock_operator
 
         # Execute core function
@@ -1375,6 +1389,7 @@ class TestCore(unittest.TestCase):
         mock_virt_install = mock.Mock()
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, {'some': 'data'})
+        mock_virt_install.get_commands.return_value = []
         mock_virt_install_class.return_value = mock_virt_install
 
         # Mock BaseImageOperator
@@ -1382,6 +1397,7 @@ class TestCore(unittest.TestCase):
         mock_operator.validate_checksum.return_value = True
         mock_operator.build_system_disk.return_value = {
             'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_operator.get_commands.return_value = []
         mock_base_image_operator_class.return_value = mock_operator
 
         # Execute core function
@@ -1421,6 +1437,7 @@ class TestCore(unittest.TestCase):
         mock_virt_install = mock.Mock()
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, {'some': 'data'})
+        mock_virt_install.get_commands.return_value = []
         mock_virt_install_class.return_value = mock_virt_install
 
         # Mock BaseImageOperator
@@ -1428,6 +1445,7 @@ class TestCore(unittest.TestCase):
         mock_operator.validate_checksum.return_value = True
         mock_operator.build_system_disk.return_value = {
             'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_operator.get_commands.return_value = []
         mock_base_image_operator_class.return_value = mock_operator
 
         # Execute core function

--- a/tests/unit/modules/test_virt_install.py
+++ b/tests/unit/modules/test_virt_install.py
@@ -24,6 +24,8 @@ class TestCoreFunction(unittest.TestCase):
             'recreate': False
         }
         self.mock_module.check_mode = False
+        # Mock run_command to return proper tuple for LibvirtConnection initialization
+        self.mock_module.run_command.return_value = (0, 'linux-kernel', '')
         self.mock_module.fail_json = mock.Mock(
             side_effect=Exception("fail_json called"))
 
@@ -59,6 +61,7 @@ class TestCoreFunction(unittest.TestCase):
         # VirtInstallTool.execute returns success
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, {"msg": "VM created successfully"})
+        mock_virt_install.get_commands.return_value = []
 
         # Call core function
         rc, result = core(self.mock_module)
@@ -86,6 +89,7 @@ class TestCoreFunction(unittest.TestCase):
         # VirtInstallTool.execute returns failure
         mock_virt_install.execute.return_value = (
             False, VIRT_FAILED, {"msg": "VM creation failed"})
+        mock_virt_install.get_commands.return_value = []
 
         # Call core function
         rc, result = core(self.mock_module)
@@ -142,6 +146,7 @@ class TestCoreFunction(unittest.TestCase):
         # VirtInstallTool.execute returns success
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, {"msg": "VM recreated successfully"})
+        mock_virt_install.get_commands.return_value = []
 
         # Call core function
         rc, result = core(self.mock_module)
@@ -176,6 +181,7 @@ class TestCoreFunction(unittest.TestCase):
         # VirtInstallTool.execute returns success
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, {"msg": "VM recreated successfully"})
+        mock_virt_install.get_commands.return_value = []
 
         # Call core function
         rc, result = core(self.mock_module)
@@ -320,6 +326,7 @@ class TestCoreFunction(unittest.TestCase):
         # VirtInstallTool.execute returns success
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, {"msg": "VM created successfully"})
+        mock_virt_install.get_commands.return_value = []
 
         # Call core function
         rc, result = core(self.mock_module)
@@ -351,7 +358,7 @@ class TestCoreFunction(unittest.TestCase):
         # Assertions - check result structure
         self.assertIsInstance(result, dict)
         self.assertIn('changed', result)
-        self.assertIn('orignal_message', result)  # Note: typo in original code
+        self.assertIn('original_message', result)
         self.assertIn('message', result)
         self.assertIsInstance(result['changed'], bool)
 
@@ -370,6 +377,7 @@ class TestCoreFunction(unittest.TestCase):
         mock_virt_conn.find_vm.side_effect = VMNotFound("VM not found")
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, {"msg": "VM created"})
+        mock_virt_install.get_commands.return_value = []
 
         # Call core function
         rc, result = core(self.mock_module)
@@ -392,6 +400,7 @@ class TestCoreFunction(unittest.TestCase):
         mock_virt_conn.find_vm.side_effect = VMNotFound("VM not found")
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, {"msg": "VM created"})
+        mock_virt_install.get_commands.return_value = []
 
         # Call core function
         rc, result = core(self.mock_module)
@@ -414,6 +423,7 @@ class TestCoreFunction(unittest.TestCase):
         mock_virt_conn.find_vm.side_effect = VMNotFound("VM not found")
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, {"msg": "VM created"})
+        mock_virt_install.get_commands.return_value = []
 
         # Call core function
         rc, result = core(self.mock_module)
@@ -441,6 +451,7 @@ class TestCoreFunction(unittest.TestCase):
         mock_virt_conn.find_vm.side_effect = VMNotFound("VM not found")
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, {"msg": "VM created"})
+        mock_virt_install.get_commands.return_value = []
 
         # Call core function
         rc, result = core(self.mock_module)
@@ -492,6 +503,7 @@ class TestCoreFunction(unittest.TestCase):
         }
         mock_virt_install.execute.return_value = (
             True, VIRT_SUCCESS, extra_data)
+        mock_virt_install.get_commands.return_value = []
 
         # Call core function
         rc, result = core(self.mock_module)


### PR DESCRIPTION
Return the underlying qemu-img and virt-install commands executed during provisioning via a new `commands` field.

##### SUMMARY

Add a commands return field to the virt_install and virt_cloud_instance modules, exposing the exact CLI commands executed during VM provisioning.

- virt_install: returns the virt-install command used to create the VM
- virt_cloud_instance: returns the full sequence of commands — qemu-img operations for disk preparation followed by the virt-install command

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
`virt_install`
`virt_cloud_instance`


##### ADDITIONAL INFORMATION
N/A
