### PR TITLE
fix: vendor _parse_clixml to fix ImportError on ansible-core 2.21+

### DIFF
--- a/changelogs/fragments/243-fix-libvirt_qemu-parse_clixml-import.yml
+++ b/changelogs/fragments/243-fix-libvirt_qemu-parse_clixml-import.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - libvirt_qemu - Vendor ``_parse_clixml`` locally to fix ``ImportError`` on ansible-core devel (2.21+).

--- a/plugins/connection/libvirt_qemu.py
+++ b/plugins/connection/libvirt_qemu.py
@@ -62,8 +62,8 @@ from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNo
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import raise_from
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-from ansible.plugins.shell.powershell import _parse_clixml
 from ansible.utils.display import Display
+from ansible_collections.community.libvirt.plugins.module_utils.powershell import _parse_clixml
 from functools import partial
 from os.path import exists
 

--- a/plugins/module_utils/powershell.py
+++ b/plugins/module_utils/powershell.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2014, Chris Church <chris@ninemoreminutes.com>
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""PowerShell compatibility utilities vendored from ansible-core.
+
+The _parse_clixml() function was extracted from
+ansible.plugins.shell.powershell in ansible-core stable-2.20 (the last
+release that carried it).  Starting with ansible-core devel (2.21+) the
+function was removed and the underlying logic refactored into the private
+ansible._internal._powershell._clixml module.
+
+Upstream reference (stable-2.20):
+  https://github.com/ansible/ansible/blob/stable-2.20/lib/ansible/plugins/shell/powershell.py
+
+This shim should be removed once the collection's minimum supported
+ansible-core version ships its own public replacement.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import base64
+import re
+import xml.etree.ElementTree as ET
+
+from ansible.module_utils._text import to_bytes
+
+_STRING_DESERIAL_FIND = re.compile(rb"\x00_\x00x((?:\x00[a-fA-F0-9]){4})\x00_")
+
+
+def _parse_clixml(data, stream="Error"):
+    """Parse CLIXML-encoded PowerShell output and return the stream message.
+
+    Takes a byte string like ``b'#< CLIXML\\r\\n<Objs...'`` and extracts the
+    stream message encoded in the XML data.  CLIXML is used by PowerShell to
+    encode multiple objects in stderr.
+    """
+    lines = []
+
+    def rplcr(matchobj):
+        match_hex = matchobj.group(1)
+        hex_string = match_hex.decode("utf-16-be")
+        return base64.b16decode(hex_string.upper())
+
+    while data:
+        start_idx = data.find(b"<Objs ")
+        end_idx = data.find(b"</Objs>")
+        if start_idx == -1 or end_idx == -1:
+            break
+
+        end_idx += 7
+        current_element = data[start_idx:end_idx]
+        data = data[end_idx:]
+
+        clixml = ET.fromstring(current_element)
+        namespace_match = re.match(r'{(.*)}', clixml.tag)
+        namespace = "{%s}" % namespace_match.group(1) if namespace_match else ""
+
+        entries = clixml.findall("./%sS" % namespace)
+        if not entries:
+            continue
+
+        if lines:
+            lines.append("\r\n")
+
+        for string_entry in entries:
+            actual_stream = string_entry.attrib.get('S', None)
+            if actual_stream != stream:
+                continue
+
+            b_line = (string_entry.text or "").encode("utf-16-be")
+            b_escaped = re.sub(_STRING_DESERIAL_FIND, rplcr, b_line)
+
+            lines.append(b_escaped.decode("utf-16-be", errors="surrogatepass"))
+
+    return to_bytes(''.join(lines), errors="surrogatepass")


### PR DESCRIPTION
##### SUMMARY
The `_parse_clixml` function was removed from `ansible.plugins.shell.powershell` in ansible-core devel (2.21+), breaking the `libvirt_qemu` connection plugin's import.

Vendor the function (extracted from ansible-core stable-2.20) into a new `plugins/module_utils/powershell.py` utility module so the plugin works across all supported ansible-core versions.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`libvirt_qemu`

##### ADDITIONAL INFORMATION
N/A
