### PR TITLE
feat: add support for compressed base images in virt_cloud_instance

### DIFF
--- a/changelogs/fragments/245-virt-cloud-instance-image-compression.yml
+++ b/changelogs/fragments/245-virt-cloud-instance-image-compression.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - virt_cloud_instance - Add support for compressed base images (gzip, bzip2, xz).

--- a/plugins/modules/virt_cloud_instance.py
+++ b/plugins/modules/virt_cloud_instance.py
@@ -42,7 +42,23 @@ options:
       - Path or URL to the cloud image.
       - Can be a local file path or a remote URL (http, https, ftp).
       - The image will be automatically downloaded if a URL is provided.
+      - Supports compressed images (gzip, bzip2, xz) which will be automatically decompressed.
     required: true
+  image_compression:
+    type: str
+    choices: [ auto, gzip, bzip2, xz, none ]
+    default: auto
+    version_added: "2.3.0"
+    description:
+      - The compression format of the base image.
+      - V(auto) automatically detects compression based on file extension (C(.gz), C(.bz2), C(.xz)).
+      - V(none) explicitly indicates the image is not compressed.
+      - Compressed images are decompressed to a temporary directory on each run for integrity.
+      - The decompressed image is written to the module temporary directory (C(module.tmpdir), the Ansible remote temporary directory).
+      - The decompressed image is not cached; if O(image_cache_dir) is used, it caches the downloaded compressed file, not the decompressed image.
+      - The decompressed file is normally removed automatically when the module finishes (unless the remote temporary directory is preserved,
+        e.g. with C(--keep-remote-files) / C(ANSIBLE_KEEP_REMOTE_FILES)).
+      - Only applies when O(base_image) is a compressed file.
   image_cache_dir:
     type: path
     description:
@@ -181,6 +197,10 @@ notes:
     - The O(cloud_init_auto_reboot) parameter automatically injects I(power_state.mode=reboot) at the end of user-data when enabled.
     - The module waits through the complete cloud-init process including any reboots specified in the user-data.
     - Use O(cloud_init_reboot_timeout) to control the maximum wait time for complex cloud-init configurations.
+    - Compressed images (O(image_compression)) are decompressed on every run for integrity after checksum validation.
+    - The decompressed image is written under the Ansible remote temporary directory (C(module.tmpdir)) and is normally cleaned up
+      automatically when the module completes (unless remote tmp is preserved, e.g. with C(--keep-remote-files) / C(ANSIBLE_KEEP_REMOTE_FILES)).
+    - For better performance with compressed images, manually decompress once and use the local file path.
 seealso:
   - module: community.libvirt.virt_install
     description: More general VM installation module.
@@ -265,6 +285,23 @@ EXAMPLES = """
     disks:
       - path: /var/lib/libvirt/images/test-vm.qcow2
         size: 20
+        format: qcow2
+    memory: 2048
+    vcpus: 2
+    networks:
+      - network: default
+
+# Use compressed FreeBSD cloud image
+- name: Create VM from compressed FreeBSD image
+  community.libvirt.virt_cloud_instance:
+    name: freebsd-vm-01
+    base_image: https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/FreeBSD-15.0-RELEASE-amd64-BASIC-CLOUDINIT-ufs.qcow2.xz
+    image_cache_dir: /srv/cloud-images
+    image_checksum: sha256:https://download.freebsd.org/releases/VM-IMAGES/15.0-RELEASE/amd64/Latest/CHECKSUM.SHA256
+    image_compression: auto
+    disks:
+      - path: /var/lib/libvirt/images/freebsd-vm-01.qcow2
+        size: 30
         format: qcow2
     memory: 2048
     vcpus: 2
@@ -366,6 +403,124 @@ class BaseImageOperator(object):
 
         self.base_image_path = image_path
         return self.base_image_path
+
+    def _detect_compression(self, filename):
+        """
+        Detect compression format based on file extension.
+
+        Args:
+            filename: Filename to check
+
+        Returns:
+            str: Detected compression format ('gzip', 'bzip2', 'xz', or 'none')
+        """
+        if filename.endswith('.gz'):
+            return 'gzip'
+        elif filename.endswith('.xz'):
+            return 'xz'
+        elif filename.endswith('.bz2'):
+            return 'bzip2'
+        return 'none'
+
+    def _strip_compression_extension(self, filename, compression_format):
+        """
+        Remove compression extension from filename.
+
+        Args:
+            filename: Original filename with compression extension
+            compression_format: Compression format ('gzip', 'bzip2', 'xz')
+
+        Returns:
+            str: Filename without compression extension
+        """
+        extensions = {
+            'gzip': '.gz',
+            'bzip2': '.bz2',
+            'xz': '.xz'
+        }
+        ext = extensions.get(compression_format)
+        if ext and filename.endswith(ext):
+            return filename[:-len(ext)]
+        return filename
+
+    def _decompress_file(self, source_path, dest_path, compression_format):
+        """
+        Decompress file using Python standard library.
+
+        Args:
+            source_path: Path to compressed file
+            dest_path: Path where decompressed file will be written
+            compression_format: Compression format ('gzip', 'bzip2', 'xz')
+
+        Raises:
+            Fails the module if decompression fails
+        """
+        import gzip
+        import bz2
+        try:
+            import lzma
+        except ImportError:
+            lzma = None
+
+        openers = {
+            'gzip': gzip.open,
+            'bzip2': bz2.open,
+        }
+
+        if lzma:
+            openers['xz'] = lzma.open
+        elif compression_format == 'xz':
+            self.module.fail_json(
+                msg="xz decompression requires Python 3.3+")
+
+        opener = openers.get(compression_format)
+        if not opener:
+            self.module.fail_json(
+                msg="Unsupported compression format: %s" % compression_format)
+
+        try:
+            with opener(source_path, 'rb') as src:
+                with open(dest_path, 'wb') as dst:
+                    while True:
+                        chunk = src.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        dst.write(chunk)
+        except Exception as e:
+            self.module.fail_json(
+                msg="Failed to decompress %s: %s" % (source_path, str(e)))
+
+    def decompress_image(self, compression_format):
+        """
+        Decompress the base image to temporary directory if needed.
+
+        Compressed images are always decompressed to module.tmpdir on each run
+        to ensure integrity after checksum validation. The decompressed file
+        is automatically cleaned up when the module execution completes.
+
+        Args:
+            compression_format: One of 'auto', 'gzip', 'bzip2', 'xz', 'none'
+
+        Returns:
+            str: Path to the decompressed image (or original if not compressed)
+        """
+        if compression_format == 'auto':
+            compression_format = self._detect_compression(self.base_image_path)
+
+        if compression_format == 'none':
+            return self.base_image_path
+
+        decompressed_filename = self._strip_compression_extension(
+            os.path.basename(self.base_image_path), compression_format)
+
+        decompressed_path = os.path.join(self.module.tmpdir, decompressed_filename)
+
+        if self.module.check_mode:
+            return decompressed_path
+
+        self._decompress_file(self.base_image_path, decompressed_path, compression_format)
+
+        return decompressed_path
 
     def _resolve_system_disk(self, disk_param):
         # TODO: Support specifying the system disk as a pool volume
@@ -625,6 +780,7 @@ def core(module):
     force_disk = module.params.get('force_disk', False)
     disks = module.params.get('disks', [])
     image_checksum = module.params.get('image_checksum')
+    image_compression = module.params.get('image_compression', 'auto')
     url_timeout = module.params.get('url_timeout')
     wait_for_cloud_init_reboot = module.params.get('wait_for_cloud_init_reboot', True)
     cloud_init_auto_reboot = module.params.get('cloud_init_auto_reboot', True)
@@ -675,6 +831,10 @@ def core(module):
         if not image_operator.validate_checksum():
             module.fail_json(
                 msg="The checksum of the base image does not match the expected value")
+
+        decompressed_path = image_operator.decompress_image(image_compression)
+        image_operator.base_image_path = decompressed_path
+
         system_disk = image_operator.build_system_disk(disks[0], force_disk=force_disk)
 
         # Add base_image_path to result
@@ -736,6 +896,11 @@ def main():
         force_pull=dict(type='bool', default=False),
         force_disk=dict(type='bool', default=False),
         image_checksum=dict(type='str'),
+        image_compression=dict(
+            type='str',
+            choices=['auto', 'gzip', 'bzip2', 'xz', 'none'],
+            default='auto'
+        ),
         url_timeout=dict(type='int', default=60),
         url_username=dict(type='str'),
         url_password=dict(type='str', no_log=True),

--- a/tests/unit/modules/test_virt_cloud_instance.py
+++ b/tests/unit/modules/test_virt_cloud_instance.py
@@ -998,6 +998,205 @@ class TestBaseImageOperatorCheckMode(unittest.TestCase):
         self.mock_module.fail_json.assert_called()
 
 
+class TestBaseImageOperatorDecompression(unittest.TestCase):
+    """Test BaseImageOperator decompression methods"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.mock_module = mock.Mock()
+        self.mock_module.check_mode = False
+        self.mock_module.tmpdir = '/tmp/ansible_test'
+        self.operator = BaseImageOperator(self.mock_module, '/path/to/image.qcow2.xz')
+        self.operator.base_image_path = '/path/to/image.qcow2.xz'
+
+    def test_detect_compression_xz(self):
+        """Test detecting xz compression"""
+        result = self.operator._detect_compression('image.qcow2.xz')
+        self.assertEqual(result, 'xz')
+
+    def test_detect_compression_gzip(self):
+        """Test detecting gzip compression"""
+        result = self.operator._detect_compression('image.img.gz')
+        self.assertEqual(result, 'gzip')
+
+    def test_detect_compression_bzip2(self):
+        """Test detecting bzip2 compression"""
+        result = self.operator._detect_compression('image.raw.bz2')
+        self.assertEqual(result, 'bzip2')
+
+    def test_detect_compression_none(self):
+        """Test detecting uncompressed file"""
+        result = self.operator._detect_compression('image.qcow2')
+        self.assertEqual(result, 'none')
+
+    def test_detect_compression_case_sensitive(self):
+        """Test that detection is case sensitive"""
+        result = self.operator._detect_compression('image.qcow2.XZ')
+        self.assertEqual(result, 'none')
+
+    def test_strip_compression_extension_xz(self):
+        """Test stripping xz extension"""
+        result = self.operator._strip_compression_extension('image.qcow2.xz', 'xz')
+        self.assertEqual(result, 'image.qcow2')
+
+    def test_strip_compression_extension_gzip(self):
+        """Test stripping gzip extension"""
+        result = self.operator._strip_compression_extension('image.img.gz', 'gzip')
+        self.assertEqual(result, 'image.img')
+
+    def test_strip_compression_extension_bzip2(self):
+        """Test stripping bzip2 extension"""
+        result = self.operator._strip_compression_extension('image.raw.bz2', 'bzip2')
+        self.assertEqual(result, 'image.raw')
+
+    def test_strip_compression_extension_no_extension(self):
+        """Test stripping when file doesn't have compression extension"""
+        result = self.operator._strip_compression_extension('image.qcow2', 'xz')
+        self.assertEqual(result, 'image.qcow2')
+
+    def test_strip_compression_extension_none(self):
+        """Test stripping with none format"""
+        result = self.operator._strip_compression_extension('image.qcow2.xz', 'none')
+        self.assertEqual(result, 'image.qcow2.xz')
+
+    @mock.patch('gzip.open')
+    @mock.patch('builtins.open')
+    def test_decompress_file_gzip(self, mock_open, mock_gzip_open):
+        """Test decompressing gzip file"""
+        mock_src = mock.Mock()
+        mock_src.read.side_effect = [b'data chunk', b'']
+        mock_gzip_open.return_value.__enter__.return_value = mock_src
+
+        mock_dst = mock.Mock()
+        mock_open.return_value.__enter__.return_value = mock_dst
+
+        self.operator._decompress_file('/src.gz', '/dst', 'gzip')
+
+        mock_gzip_open.assert_called_once_with('/src.gz', 'rb')
+        mock_open.assert_called_once_with('/dst', 'wb')
+        mock_dst.write.assert_called_once_with(b'data chunk')
+
+    @mock.patch('bz2.open')
+    @mock.patch('builtins.open')
+    def test_decompress_file_bzip2(self, mock_open, mock_bz2_open):
+        """Test decompressing bzip2 file"""
+        mock_src = mock.Mock()
+        mock_src.read.side_effect = [b'compressed data', b'']
+        mock_bz2_open.return_value.__enter__.return_value = mock_src
+
+        mock_dst = mock.Mock()
+        mock_open.return_value.__enter__.return_value = mock_dst
+
+        self.operator._decompress_file('/src.bz2', '/dst', 'bzip2')
+
+        mock_bz2_open.assert_called_once_with('/src.bz2', 'rb')
+        mock_dst.write.assert_called_once_with(b'compressed data')
+
+    @mock.patch('lzma.open')
+    @mock.patch('builtins.open')
+    def test_decompress_file_xz(self, mock_open, mock_lzma_open):
+        """Test decompressing xz file"""
+        mock_src = mock.Mock()
+        mock_src.read.side_effect = [b'xz data', b'']
+        mock_lzma_open.return_value.__enter__.return_value = mock_src
+
+        mock_dst = mock.Mock()
+        mock_open.return_value.__enter__.return_value = mock_dst
+
+        self.operator._decompress_file('/src.xz', '/dst', 'xz')
+
+        mock_lzma_open.assert_called_once_with('/src.xz', 'rb')
+        mock_dst.write.assert_called_once_with(b'xz data')
+
+    def test_decompress_file_unsupported_format(self):
+        """Test decompressing with unsupported format"""
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        with self.assertRaises(Exception):
+            self.operator._decompress_file('/src', '/dst', 'invalid')
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="Unsupported compression format: invalid"
+        )
+
+    @mock.patch('gzip.open')
+    @mock.patch('builtins.open')
+    def test_decompress_file_error_handling(self, mock_open, mock_gzip_open):
+        """Test error handling during decompression"""
+        mock_gzip_open.side_effect = IOError("Cannot read file")
+        self.mock_module.fail_json.side_effect = Exception("Module failed")
+
+        with self.assertRaises(Exception):
+            self.operator._decompress_file('/src.gz', '/dst', 'gzip')
+
+        self.mock_module.fail_json.assert_called_once()
+        call_args = self.mock_module.fail_json.call_args[1]
+        self.assertIn("Failed to decompress", call_args['msg'])
+
+    def test_decompress_image_none_returns_original(self):
+        """Test decompress_image with none format returns original path"""
+        result = self.operator.decompress_image('none')
+        self.assertEqual(result, '/path/to/image.qcow2.xz')
+
+    def test_decompress_image_auto_detect_xz(self):
+        """Test decompress_image with auto detection for xz"""
+        with mock.patch.object(self.operator, '_decompress_file') as mock_decompress:
+            result = self.operator.decompress_image('auto')
+
+            expected_path = '/tmp/ansible_test/image.qcow2'
+            self.assertEqual(result, expected_path)
+            mock_decompress.assert_called_once_with(
+                '/path/to/image.qcow2.xz',
+                expected_path,
+                'xz'
+            )
+
+    def test_decompress_image_auto_detect_none(self):
+        """Test decompress_image with auto detection for uncompressed file"""
+        self.operator.base_image_path = '/path/to/image.qcow2'
+
+        result = self.operator.decompress_image('auto')
+
+        self.assertEqual(result, '/path/to/image.qcow2')
+
+    def test_decompress_image_explicit_format(self):
+        """Test decompress_image with explicit format"""
+        self.operator.base_image_path = '/path/to/image.qcow2.xz'
+
+        with mock.patch.object(self.operator, '_decompress_file') as mock_decompress:
+            result = self.operator.decompress_image('xz')
+
+            expected_path = '/tmp/ansible_test/image.qcow2'
+            self.assertEqual(result, expected_path)
+            mock_decompress.assert_called_once_with(
+                '/path/to/image.qcow2.xz',
+                expected_path,
+                'xz'
+            )
+
+    def test_decompress_image_check_mode(self):
+        """Test decompress_image in check_mode doesn't actually decompress"""
+        self.mock_module.check_mode = True
+
+        with mock.patch.object(self.operator, '_decompress_file') as mock_decompress:
+            result = self.operator.decompress_image('xz')
+
+            expected_path = '/tmp/ansible_test/image.qcow2'
+            self.assertEqual(result, expected_path)
+            mock_decompress.assert_not_called()
+
+    def test_decompress_image_to_tmpdir(self):
+        """Test that decompression always goes to tmpdir"""
+        self.operator.image_cache_dir = '/var/cache'
+        self.operator.base_image_path = '/var/cache/image.qcow2.xz'
+
+        with mock.patch.object(self.operator, '_decompress_file') as mock_decompress:
+            result = self.operator.decompress_image('xz')
+
+            self.assertIn('/tmp/ansible_test/', result)
+            self.assertNotIn('/var/cache/', result)
+
+
 class TestCore(unittest.TestCase):
     """Test core() function"""
 
@@ -1458,6 +1657,89 @@ class TestCore(unittest.TestCase):
         )
 
         # Should return success
+        self.assertEqual(rc, VIRT_SUCCESS)
+        self.assertTrue(result['changed'])
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.BaseImageOperator')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.LibvirtWrapper')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.validate_disks')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.update_virtinst_params')
+    def test_core_compressed_image_xz(self, mock_update_params, mock_validate_disks,
+                                      mock_libvirt_wrapper_class, mock_virt_install_class,
+                                      mock_base_image_operator_class):
+        """Test core() with xz compressed image"""
+        from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import core, VIRT_SUCCESS
+        from ansible_collections.community.libvirt.plugins.module_utils.libvirt import VMNotFound
+
+        self.mock_module.params['base_image'] = '/path/to/image.qcow2.xz'
+        self.mock_module.params['image_compression'] = 'auto'
+
+        mock_virt_conn = mock.Mock()
+        mock_virt_conn.find_vm.side_effect = VMNotFound("VM not found")
+        mock_libvirt_wrapper_class.return_value = mock_virt_conn
+
+        mock_virt_install = mock.Mock()
+        mock_virt_install.execute.return_value = (True, VIRT_SUCCESS, {})
+        mock_virt_install.get_commands.return_value = []
+        mock_virt_install_class.return_value = mock_virt_install
+
+        mock_operator = mock.Mock()
+        mock_operator.validate_checksum.return_value = True
+        mock_operator.decompress_image.return_value = '/tmp/ansible_test/image.qcow2'
+        mock_operator.base_image_path = '/tmp/ansible_test/image.qcow2'
+        mock_operator.build_system_disk.return_value = {
+            'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_operator.get_commands.return_value = []
+        mock_base_image_operator_class.return_value = mock_operator
+
+        rc, result = core(self.mock_module)
+
+        mock_operator.fetch_image.assert_called_once()
+        mock_operator.validate_checksum.assert_called_once()
+        mock_operator.decompress_image.assert_called_once_with('auto')
+        mock_operator.build_system_disk.assert_called_once()
+
+        self.assertEqual(rc, VIRT_SUCCESS)
+        self.assertTrue(result['changed'])
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.BaseImageOperator')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.LibvirtWrapper')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.validate_disks')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance.update_virtinst_params')
+    def test_core_compressed_image_none(self, mock_update_params, mock_validate_disks,
+                                        mock_libvirt_wrapper_class, mock_virt_install_class,
+                                        mock_base_image_operator_class):
+        """Test core() with compression_format='none' uses original file"""
+        from ansible_collections.community.libvirt.plugins.modules.virt_cloud_instance import core, VIRT_SUCCESS
+        from ansible_collections.community.libvirt.plugins.module_utils.libvirt import VMNotFound
+
+        self.mock_module.params['base_image'] = '/path/to/image.qcow2'
+        self.mock_module.params['image_compression'] = 'none'
+
+        mock_virt_conn = mock.Mock()
+        mock_virt_conn.find_vm.side_effect = VMNotFound("VM not found")
+        mock_libvirt_wrapper_class.return_value = mock_virt_conn
+
+        mock_virt_install = mock.Mock()
+        mock_virt_install.execute.return_value = (True, VIRT_SUCCESS, {})
+        mock_virt_install.get_commands.return_value = []
+        mock_virt_install_class.return_value = mock_virt_install
+
+        mock_operator = mock.Mock()
+        mock_operator.validate_checksum.return_value = True
+        mock_operator.decompress_image.return_value = '/path/to/image.qcow2'
+        mock_operator.base_image_path = '/path/to/image.qcow2'
+        mock_operator.build_system_disk.return_value = {
+            'path': '/var/lib/libvirt/images/test.qcow2'}
+        mock_operator.get_commands.return_value = []
+        mock_base_image_operator_class.return_value = mock_operator
+
+        rc, result = core(self.mock_module)
+
+        mock_operator.decompress_image.assert_called_once_with('none')
+
         self.assertEqual(rc, VIRT_SUCCESS)
         self.assertTrue(result['changed'])
 


### PR DESCRIPTION
##### SUMMARY

Add support for decompressing compressed cloud images (gzip, bzip2, xz) in the `virt_cloud_instance` module.

This change introduces a new `image_compression` parameter (default: `auto`) that automatically detects and decompresses compressed cloud images based on file extension. The module caches the compressed file in `image_cache_dir` and decompresses it to a temporary directory on each run to ensure data integrity after checksum validation. Uses Python standard library (gzip, bz2, lzma) with no additional dependencies required.

Fixes #235

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`virt_cloud_instance`

##### ADDITIONAL INFORMATION

**Test playbook**
```yaml
  - name: Create Test virtual machine
    community.libvirt.virt_cloud_instance:
      name: '{{ item }}'
      state: present
      base_image: /srv/cloudimg-cache/noble-server-cloudimg-amd64.img.xz
      image_compression: xz
      image_cache_dir: '{{ cloudimg_cache_dir }}'
      force_pull: false
      force_disk: true
      url_timeout: 600
      memory: 4096
      vcpus: 2
      osinfo:
        name: '{{ gitea_vm_osname }}'
      graphics:
        type: vnc
      iothreads: 1
      disks:
        - path: /srv/kvm/images/{{ item }}.qcow2
          size: 50
          bus: virtio
          cache: none
          format: qcow2
          driver:
            io: native
            discard: unmap
            detect_zeroes: unmap        
      networks:
        - bridge: ovsbr1
          model:
            type: virtio
          virtualport:
            type: openvswitch
      cloud_init:
        meta_data: |
          local-hostname: {{ item }}
          fqdn: {{ item }}.{{ internal_domain }}
        user_data: |
          #cloud-config
          users:
            - name: sysadm
              sudo: ALL=(ALL) NOPASSWD:ALL
              shell: /bin/bash
              ssh_authorized_keys:
                - "{{ test_vm_ssh_key }}"
          ssh_pwauth: false
          apt:
            preserve_sources_list: false
            primary:
              - arches: [default]
                uri: http://mirrors.ustc.edu.cn/ubuntu/
            security:
              - arches: [default]
                uri: http://mirrors.ustc.edu.cn/ubuntu/
        network_config: |
          version: 2
          ethernets:
            enp1s0:
              dhcp4: false
              addresses:
              - {{ hostvars[item].ansible_host }}/24
              routes:
              - to: default
                via: 192.168.3.1
              nameservers:
                addresses:
                - 192.168.3.1
                search:
                - {{ internal_domain }}
      wait_for_cloud_init_reboot: true
      autostart: true
    loop: "{{ groups['test_nodes'] }}"
```
