### PR TITLE
Add configuration option to disable alternate id group creation

### DIFF
--- a/changelogs/fragments/246-add-alias-groups-option.yml
+++ b/changelogs/fragments/246-add-alias-groups-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory - added option ``alternate_id_groups`` (default ``true``)

--- a/plugins/inventory/libvirt.py
+++ b/plugins/inventory/libvirt.py
@@ -25,8 +25,7 @@ options:
     inventory_hostname:
         description: |
             What to register as the inventory hostname.
-            If set to 'uuid' the uuid of the server will be used and a
-            group will be created for the server name.
+            If set to 'uuid' the uuid of the server will be used.
             If set to 'name' the name of the server will be used unless
             there are more than one server with the same name in which
             case the 'uuid' logic will be used.
@@ -36,6 +35,12 @@ options:
             - name
             - uuid
         default: "name"
+    alternate_id_groups:
+        description: |
+            Determines whether groups will be created using the alternate id
+            (hostname or UUID)
+        type: bool
+        default: true
 '''
 
 EXAMPLES = r'''
@@ -114,8 +119,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             # TODO(daveol): Fix "Invalid characters were found in group names"
             # This warning is generated because of uuid's
             self.inventory.add_host(inventory_hostname)
-            self.inventory.add_group(inventory_hostname_alias)
-            self.inventory.add_child(inventory_hostname_alias, inventory_hostname)
+
+            if self.get_option('alternate_id_groups'):
+                self.inventory.add_group(inventory_hostname_alias)
+                self.inventory.add_child(inventory_hostname_alias, inventory_hostname)
 
             if connection_plugin is not None:
                 self.inventory.set_variable(


### PR DESCRIPTION
##### SUMMARY

This change adds a new boolean configuration option `alternate_id_groups` to the inventory plugin. Setting it to `false` means the discovered hosts will no longer be added to auto-generated groups based on the alternate id (name or UUID). The default setting is `true`, preserving existing functionality.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`plugins/inventory/libvirt.py`

##### ADDITIONAL INFORMATION

EOT:


```sh
$ ansible-test units --color -v --docker default
<redacted for brevity>
============================= 304 passed in 3.59s ==============================
```

And on my homelab, with this config:

```sh
plugin: community.libvirt.libvirt
uri: 'qemu+ssh://cabub@lab/system'

inventory_hostname: name
alternate_id_groups: false
```

The resulting hosts are not assigned to uuid groups:

```sh
ansible-inventory -i inventory --graph       
libvirt: QEMU Driver error : Requested operation is not valid: domain is not running
libvirt: Domain Config error : Requested operation is not valid: domain is not running
libvirt: QEMU Driver error : Requested operation is not valid: domain is not running
libvirt: Domain Config error : Requested operation is not valid: domain is not running
libvirt: QEMU Driver error : Requested operation is not valid: domain is not running
libvirt: Domain Config error : Requested operation is not valid: domain is not running
@all:
  |--@ungrouped:
  |  |--router
  |  |--data
  |  |--bastion
```
