### PR TITLE
fix: add cloud-config header when converting cloudinit user-data

### DIFF
--- a/changelogs/fragments/254-add-cloud-config-header-when-converting-cloudinit-user-data.yml
+++ b/changelogs/fragments/254-add-cloud-config-header-when-converting-cloudinit-user-data.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - virt_install - added cloud-config header when converting cloud-init user-data from dictionary form.
+  - virt_cloud_instance - added cloud-config header when converting cloud-init user-data from dictionary form.

--- a/plugins/module_utils/virt_install.py
+++ b/plugins/module_utils/virt_install.py
@@ -259,7 +259,7 @@ class VirtInstallTool(object):
 
         return combined_items
 
-    def _convert_raw_to_string(self, value):
+    def _convert_raw_to_string(self, value, is_userdata=False):
         """Convert raw type parameter (str or dict) to string content.
         """
         if isinstance(value, str):
@@ -267,7 +267,8 @@ class VirtInstallTool(object):
         elif isinstance(value, dict):
             try:
                 import yaml
-                return yaml.safe_dump(value, default_flow_style=False, allow_unicode=True)
+                userdata_prefix = "#cloud-config\n" if is_userdata else ""
+                return userdata_prefix + yaml.safe_dump(value, default_flow_style=False, allow_unicode=True)
             except ImportError:
                 self.module.fail_json(
                     msg="PyYAML is required to process dictionary cloud-init parameters")
@@ -518,7 +519,8 @@ class VirtInstallTool(object):
                 cloud_init_params['meta-data'] = self._save_string_to_tempfile(meta_data_content)
                 del cloud_init_params['meta_data']
             if cloud_init_params.get('user_data'):
-                user_data_content = self._convert_raw_to_string(cloud_init_params['user_data'])
+                user_data_content = self._convert_raw_to_string(
+                    cloud_init_params['user_data'], is_userdata=True)
                 cloud_init_params['user-data'] = self._save_string_to_tempfile(user_data_content)
                 del cloud_init_params['user_data']
 

--- a/plugins/modules/virt_cloud_instance.py
+++ b/plugins/modules/virt_cloud_instance.py
@@ -746,17 +746,18 @@ def update_virtinst_params(module, virtInstall, system_disk, extra_user_data=Non
         if virtInstall.params.get('cloud_init') is None:
             virtInstall.params['cloud_init'] = {}
 
-        orignal_user_data = virtInstall.params['cloud_init'].get('user_data', "")
+        original_user_data = virtInstall.params['cloud_init'].get('user_data', "")
 
-        if isinstance(orignal_user_data, dict):
+        if isinstance(original_user_data, dict):
             try:
                 import yaml
-                orignal_user_data = yaml.safe_dump(orignal_user_data, default_flow_style=False, allow_unicode=True)
+                original_user_data = "#cloud-config\n" + yaml.safe_dump(
+                    original_user_data, default_flow_style=False, allow_unicode=True)
             except ImportError:
                 module.fail_json(
                     msg="PyYAML is required to process dictionary cloud-init parameters")
 
-        modified_user_data = orignal_user_data + extra_user_data
+        modified_user_data = original_user_data + extra_user_data
         virtInstall.params['cloud_init']['user_data'] = modified_user_data
 
 

--- a/tests/unit/module_utils/test_virt_install.py
+++ b/tests/unit/module_utils/test_virt_install.py
@@ -2082,6 +2082,7 @@ class TestBuildCommand(unittest.TestCase):
             yaml_content = f.read()
 
         # Verify the YAML contains expected content
+        self.assertTrue(yaml_content.startswith('#cloud-config'))
         self.assertIn('users:', yaml_content)
         self.assertIn('name: admin', yaml_content)
         self.assertIn('sudo: ALL=(ALL) NOPASSWD:ALL', yaml_content)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When providing the cloudinit user-data as dictionary, the conversion to string does not include the `#cloud-config` header. Hence it is invalid and never executed. When specifying the user-data as string (e.g. with yaml multiline `user_data: |`) it's easy to include the header oneself.

This PR adds the header when user-data is converted from dictionary to string.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.libvirt.virt_install

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

### Example Config:

I am using the noble-server-cloudimg-amd64.img image for testing this. Password for the molecule user is also molecule.

```yaml
# non-working example -> login not possible via console
community.libvirt.virt_install:
        name: instance01
        cloud_init:
          user_data:
            users:
              - create_groups: true
                groups: sudo
                passwd: $y$j9T$riArJL5F4eYfo1oWhyI7p/$QlzyZgBEDkYxZ4gdJc7yz2kX7sphKU9aPiuUVCBnLg9
                name: molecule
                shell: /bin/bash
                sudo:
                  - ALL=(ALL) NOPASSWD:ALL
```

```yaml
# working example -> login possible via console
community.libvirt.virt_install:
        name: instance01
        cloud_init:
          user_data: |-
            #cloud-config
            users:
              - create_groups: true
                groups: sudo
                passwd: $y$j9T$riArJL5F4eYfo1oWhyI7p/$QlzyZgBEDkYxZ4gdJc7yz2kX7sphKU9aPiuUVCBnLg9
                name: molecule
                shell: /bin/bash
                sudo:
                  - ALL=(ALL) NOPASSWD:ALL
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

I did not yet understand your test setup so hoping the pipeline will suffice :)