### PR TITLE
fix: replaced deprecated imports to avoid ansible-core deprecation warnings

### DIFF
--- a/changelogs/fragments/255-replace-private-text-imports.yml
+++ b/changelogs/fragments/255-replace-private-text-imports.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - plugins - replaced deprecated imports from 'ansible.module_utils._text' with 'ansible.module_utils.common.text.converters' to avoid ansible-core deprecation warnings and prepare for removal of the private import path in ansible-core 2.24.

--- a/plugins/connection/libvirt_lxc.py
+++ b/plugins/connection/libvirt_lxc.py
@@ -49,7 +49,7 @@ from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils.common.process import get_bin_path
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.utils.display import Display
 

--- a/plugins/connection/libvirt_qemu.py
+++ b/plugins/connection/libvirt_qemu.py
@@ -59,8 +59,7 @@ else:
     LIBVIRT_IMPORT_ERROR = None
 
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
-from ansible.module_utils._text import to_bytes, to_native, to_text
-from ansible.module_utils.six import raise_from
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.utils.display import Display
 from ansible_collections.community.libvirt.plugins.module_utils.powershell import _parse_clixml
@@ -91,9 +90,7 @@ class Connection(ConnectionBase):
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         if LIBVIRT_IMPORT_ERROR:
-            raise_from(
-                AnsibleError('libvirt python bindings must be installed to use this plugin'),
-                LIBVIRT_IMPORT_ERROR)
+            raise AnsibleError('libvirt python bindings must be installed to use this plugin') from LIBVIRT_IMPORT_ERROR
 
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
 

--- a/plugins/module_utils/powershell.py
+++ b/plugins/module_utils/powershell.py
@@ -24,7 +24,7 @@ import base64
 import re
 import xml.etree.ElementTree as ET
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 _STRING_DESERIAL_FIND = re.compile(rb"\x00_\x00x((?:\x00[a-fA-F0-9]){4})\x00_")
 

--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -176,7 +176,7 @@ else:
     HAS_XML = True
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 ALL_COMMANDS = []
 VM_COMMANDS = ['create', 'define', 'destroy', 'get_xml', 'get_interfaces', 'pause', 'shutdown', 'status', 'start', 'stop', 'undefine', 'unpause', 'uuid']

--- a/plugins/modules/virt_net.py
+++ b/plugins/modules/virt_net.py
@@ -139,7 +139,7 @@ else:
     HAS_XML = True
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 VIRT_FAILED = 1

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -23,7 +23,7 @@ import os
 
 from ansible.errors import AnsibleParserError
 from ansible.parsing.dataloader import DataLoader
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 
 
 class DictDataLoader(DataLoader):

--- a/tests/unit/mock/procenv.py
+++ b/tests/unit/mock/procenv.py
@@ -26,8 +26,9 @@ import json
 from contextlib import contextmanager
 from io import BytesIO, StringIO
 from ansible_collections.ansible.libvirt.tests.unit.compat import unittest
-from ansible.module_utils.six import PY3
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
+
+PY3 = sys.version_info[0] == 3
 
 
 @contextmanager

--- a/tests/unit/mock/vault_helper.py
+++ b/tests/unit/mock/vault_helper.py
@@ -15,7 +15,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible.parsing.vault import VaultSecret
 


### PR DESCRIPTION
##### SUMMARY

This PR updates community.libvirt to stop using the deprecated private Ansible text helper import path by replacing 'ansible.module_utils._text' with 'ansible.module_utils.common.text.converters'.

Fixes #252

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`plugins`

##### ADDITIONAL INFORMATION
N/A