### PR TITLE
Revert 257

### DIFF
--- a/changelogs/fragments/257-inventory-add-filter.yml
+++ b/changelogs/fragments/257-inventory-add-filter.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - inventory - added option ``filter`` (default ``.*``) to include domains by name or uuid which match regex.

--- a/plugins/inventory/libvirt.py
+++ b/plugins/inventory/libvirt.py
@@ -41,15 +41,6 @@ options:
             (hostname or UUID)
         type: bool
         default: true
-    filter:
-        description: |
-            Regex applied to each domain's name or UUID (whichever
-            ``inventory_hostname`` selects). Domains are skipped unless
-            the regex matches. Uses Python ``re.search`` semantics, so
-            anchor with ``^`` / ``$`` for an exact match.
-        type: str
-        default: ".*"
-        version_added: '2.3.0'
 '''
 
 EXAMPLES = r'''
@@ -60,14 +51,7 @@ uri: 'lxc:///'
 # Connect to qemu
 plugin: community.libvirt.libvirt
 uri: 'qemu:///system'
-
-# Only include domains whose names start with "prod-"
-plugin: community.libvirt.libvirt
-uri: 'qemu:///system'
-filter: '^prod-'
 '''
-
-import re
 
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.errors import AnsibleError
@@ -117,19 +101,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             'QEMU': 'community.libvirt.libvirt_qemu'
         }).get(connection.getType())
 
-        # Catch bad regex
-        try:
-            domain_filter = re.compile(self.get_option('filter'))
-        except re.error as e:
-            raise AnsibleError(f"invalid 'filter' regex: {e}") from e
-
         for server in connection.listAllDomains():
-            match_target = (server.UUIDString()
-                            if self.get_option('inventory_hostname') == 'uuid'
-                            else server.name())
-            if not domain_filter.search(match_target):
-                continue
-
             inventory_hostname = dict({
                 'uuid': server.UUIDString(),
                 'name': server.name()


### PR DESCRIPTION
MR 257 was merged with the wrong author attribution when squashing - that should not have happened, but the GH interface is not very clear. I should have done it on the CLI like I normally would.

This MR reverts that commit, then cherry-picks the commit merged with 257, with the right attribute.

This should be authored by @yorick1989. If I can, I'll clean up `main` and force push, but I don't have permissions to do that.