### PR TITLE
feat(virt_install): add passt network support with value shorthand and structured user type

### DIFF
--- a/changelogs/fragments/265-passt-network-support.yml
+++ b/changelogs/fragments/265-passt-network-support.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "virt_install - add passt network support with ``value`` shorthand and structured ``type: user`` form (https://github.com/ansible-collections/community.libvirt/issues/231)."
+  - "virt_cloud_instance - add passt network support via shared network schema (https://github.com/ansible-collections/community.libvirt/issues/231)."

--- a/plugins/doc_fragments/virt_install.py
+++ b/plugins/doc_fragments/virt_install.py
@@ -354,7 +354,7 @@ options:
             type: str
             description:
               - Set the vendor id seen by the guest. It must be exactly 12 characters long.
-              - Typical possible values are I(AuthenticAMD) and I(GenuineIntel).
+              - Typical possible values are V(AuthenticAMD) and V(GenuineIntel).
       match:
         type: str
         choices: [ exact, minimum, strict ]
@@ -368,7 +368,7 @@ options:
         type: str
         description:
           - Specify CPU vendor requested by the guest
-          - The list of supported vendors can be found in I(cpu_map/*_vendors.xml).
+          - The list of supported vendors can be found in C(cpu_map/*_vendors.xml).
       features:
         type: dict
         description:
@@ -1240,12 +1240,20 @@ options:
       - Connect the guest to the host network.
       - Empty list V([]) means no default network interface.
     suboptions:
+      value:
+        type: str
+        description:
+          - Shorthand network type selector.
+          - Use V(passt) for passt user-mode networking.
+          - Mutually exclusive with O(networks[].network), O(networks[].bridge), and O(networks[].hostdev).
+        version_added: 2.3.0
       type:
         type: str
-        choices: [ direct ]
+        choices: [ direct, user ]
         description:
           - The type of network interface.
           - V(direct) provides direct attachment to host network interface using macvtap.
+          - V(user) provides user-mode networking (SLIRP) with optional passt backend.
           - If omitted, the type of network interface is determined by other options.
       network:
         type: str
@@ -1316,8 +1324,8 @@ options:
         description:
           - Specify the details of the direct attached macvtap interface.
           - The dictionary contains key/value pairs that define individual properties.
-          - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
-          - "Example: I(source={value: bond0, mode: bridge})"
+          - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
+          - "Example: C(source={value: bond0, mode: bridge})"
       target:
         type: dict
         description:
@@ -1333,7 +1341,22 @@ options:
         description:
           - Configure virtual port settings for the network interface.
           - The dictionary contains key/value pairs that define individual properties.
-          - Common properties include I(type) (e.g. V(802.1Qbg), V(802.1Qbh), V(openvswitch), V(midonet)) and C(parameters) containing type-specific settings.
+          - Common properties include C(type) (e.g. V(802.1Qbg), V(802.1Qbh), V(openvswitch), V(midonet)) and C(parameters) containing type-specific settings.
+      backend:
+        type: dict
+        description:
+          - Configure the backend for user-mode networking.
+          - The dictionary contains key/value pairs that define individual properties.
+          - Common properties include C(type) (e.g. V(passt)) and C(log_file).
+        version_added: 2.3.0
+      port_forward:
+        type: list
+        elements: str
+        description:
+          - Configure port forwarding rules for user-mode networking.
+          - Each entry is a string in the format C(proto:hostport:guestport) or C(hostport:guestport).
+          - Protocol suffixes like C(/udp) are supported.
+        version_added: 2.3.0
       trust_guest_rx_filters:
         type: bool
         description:
@@ -1347,7 +1370,7 @@ options:
     description:
       - Configure the graphical display for the guest virtual machine.
       - The dictionary contains key/value pairs that define individual properties.
-      - Common properties include I(type) (e.g. V(vnc), V(spice)) and I(listen).
+      - Common properties include C(type) (e.g. V(vnc), V(spice)) and C(listen).
   graphics_devices:
     type: list
     elements: dict
@@ -1394,8 +1417,8 @@ options:
     description:
       - Attach a controller device to the guest.
       - The dictionary contains key/value pairs that define individual controller properties.
-      - Examples include I(type=usb,model=none) to disable USB, or I(type=scsi,model=virtio-scsi) for VirtIO SCSI.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - Examples include C(type=usb,model=none) to disable USB, or C(type=scsi,model=virtio-scsi) for VirtIO SCSI.
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   controller_devices:
     type: list
     elements: dict
@@ -1411,7 +1434,7 @@ options:
       - Attach an input device to the guest.
       - Input device types include mouse, tablet, or keyboard.
       - The dictionary contains key/value pairs that define individual input device properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   input_devices:
     type: list
     elements: dict
@@ -1426,7 +1449,7 @@ options:
     description:
       - Attach a physical host device to the guest.
       - The dictionary contains key/value pairs that define individual host device properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   host_devices:
     type: list
     elements: dict
@@ -1441,8 +1464,8 @@ options:
     description:
       - Attach a virtual audio device to the guest.
       - The dictionary contains key/value pairs that define individual sound device properties.
-      - Common properties include I(model) (e.g. V(ich6), V(ich9), V(ac97)).
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - Common properties include C(model) (e.g. V(ich6), V(ich9), V(ac97)).
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   sound_devices:
     type: list
     elements: dict
@@ -1457,7 +1480,7 @@ options:
     description:
       - Configure host audio output for the guest's sound hardware.
       - The dictionary contains key/value pairs that define individual audio backend properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   audio_devices:
     type: list
     elements: dict
@@ -1472,7 +1495,7 @@ options:
     description:
       - Attach a virtual hardware watchdog device to the guest.
       - The dictionary contains key/value pairs that define individual watchdog properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   watchdog_devices:
     type: list
     elements: dict
@@ -1487,7 +1510,7 @@ options:
     description:
       - Attach a serial device to the guest with various redirection options.
       - The dictionary contains key/value pairs that define individual serial device properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   serial_devices:
     type: list
     elements: dict
@@ -1502,7 +1525,7 @@ options:
     description:
       - Attach a parallel device to the guest.
       - The dictionary contains key/value pairs that define individual parallel device properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   parallel_devices:
     type: list
     elements: dict
@@ -1517,7 +1540,7 @@ options:
     description:
       - Attach a communication channel device to connect the guest and host machine.
       - The dictionary contains key/value pairs that define individual channel properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   channel_devices:
     type: list
     elements: dict
@@ -1532,8 +1555,8 @@ options:
     description:
       - Connect a text console between the guest and host.
       - The dictionary contains key/value pairs that define individual console properties.
-      - Common properties include I(type) and I(target) for different console types.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - Common properties include C(type) and C(target) for different console types.
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   console_devices:
     type: list
     elements: dict
@@ -1548,7 +1571,7 @@ options:
     description:
       - Specify what video device model will be attached to the guest.
       - The dictionary contains key/value pairs that define individual video device properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   video_devices:
     type: list
     elements: dict
@@ -1563,7 +1586,7 @@ options:
     description:
       - Configure a virtual smartcard device.
       - The dictionary contains key/value pairs that define individual smartcard properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   smartcard_devices:
     type: list
     elements: dict
@@ -1578,8 +1601,8 @@ options:
     description:
       - Add a redirected device for USB or other device redirection.
       - The dictionary contains key/value pairs that define individual redirection properties.
-      - Common properties include I(bus=usb), I(type=tcp) or I(type=spicevmc).
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - Common properties include C(bus=usb), C(type=tcp) or C(type=spicevmc).
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   redirected_devices:
     type: list
     elements: dict
@@ -1594,8 +1617,8 @@ options:
     description:
       - Attach a virtual memory balloon device to the guest.
       - The dictionary contains key/value pairs that define individual memory balloon properties.
-      - Common properties include I(model) (e.g. V(virtio), V(xen)).
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - Common properties include C(model) (e.g. V(virtio), V(xen)).
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   memballoon_devices:
     type: list
     elements: dict
@@ -1610,7 +1633,7 @@ options:
     description:
       - Configure a virtual TPM (Trusted Platform Module) device.
       - The dictionary contains key/value pairs that define individual TPM properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   tpm_devices:
     type: list
     elements: dict
@@ -1625,7 +1648,7 @@ options:
     description:
       - Configure a virtual random number generator (RNG) device.
       - The dictionary contains key/value pairs that define individual RNG properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   rng_devices:
     type: list
     elements: dict
@@ -1640,7 +1663,7 @@ options:
     description:
       - Attach a panic notifier device to the guest.
       - The dictionary contains key/value pairs that define individual panic device properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   panic_devices:
     type: list
     elements: dict
@@ -1655,7 +1678,7 @@ options:
     description:
       - Attach a shared memory device to the guest.
       - The dictionary contains key/value pairs that define individual shared memory properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   shmem_devices:
     type: list
     elements: dict
@@ -1670,7 +1693,7 @@ options:
     description:
       - Configure a vsock host/guest interface.
       - The dictionary contains key/value pairs that define individual vsock properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   vsock_devices:
     type: list
     elements: dict
@@ -1685,7 +1708,7 @@ options:
     description:
       - Add an IOMMU device to the guest.
       - The dictionary contains key/value pairs that define individual IOMMU properties.
-      - "You can use the special attribute I(value) to specify a primary value that appears before other properties in the command line."
+      - "You can use the special attribute C(value) to specify a primary value that appears before other properties in the command line."
   iommu_devices:
     type: list
     elements: dict

--- a/plugins/module_utils/virt_install.py
+++ b/plugins/module_utils/virt_install.py
@@ -595,6 +595,10 @@ class VirtInstallTool(object):
             network_mapping = {
                 'trust_guest_rx_filters': ('trustGuestRxFilters', None),
                 'state': ('link.state', None),
+                'port_forward': ('portForward', None),
+                'backend': ('backend', {
+                    'log_file': ('logFile', None),
+                }),
             }
             for network in network_param:
                 self._add_parameter('--network',
@@ -845,6 +849,21 @@ class VirtInstallTool(object):
                         self.module.fail_json(
                             msg="cloud_init.{} must be a string or dictionary, got {}".format(
                                 param_name, type(param_value).__name__))
+
+        self._validate_network_params()
+
+    def _validate_network_params(self):
+        networks = self.params.get('networks')
+        if not networks:
+            return
+
+        selectors = ['value', 'network', 'bridge', 'hostdev']
+        for net in networks:
+            present = [s for s in selectors if net.get(s)]
+            if len(present) > 1:
+                self.module.fail_json(
+                    msg="network entry specifies conflicting selectors: {}".format(
+                        ', '.join(present)))
 
     def _build_command(self):
         """Build the complete virt-install command"""
@@ -1573,7 +1592,8 @@ def get_networks_args():
             type='list',
             elements="dict",
             options=dict(
-                type=dict(type='str', choices=['direct']),
+                value=dict(type='str'),
+                type=dict(type='str', choices=['direct', 'user']),
                 network=dict(type='str'),
                 bridge=dict(type='str'),
                 hostdev=dict(type='str'),
@@ -1590,6 +1610,8 @@ def get_networks_args():
                 address=dict(type='dict'),
                 virtualport=dict(type='dict'),
                 trust_guest_rx_filters=dict(type='bool'),
+                backend=dict(type='dict'),
+                port_forward=dict(type='list', elements='str'),
             ),
         ),
     )

--- a/tests/unit/module_utils/test_virt_install.py
+++ b/tests/unit/module_utils/test_virt_install.py
@@ -1131,6 +1131,157 @@ class TestBuildCommand(unittest.TestCase):
         self.assertEqual(len(network_args), 1)
         self.assertEqual(network_args[0], 'none')
 
+    def test_network_passt_shorthand(self):
+        """Test passt network shorthand via value primary key"""
+        self.mock_module.params = {
+            'name': 'test-vm',
+            'memory': 2048,
+            'networks': [
+                {
+                    'value': 'passt',
+                    'port_forward': ['8080:80', '3478/udp', '2222:22']
+                }
+            ]
+        }
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install._build_command()
+
+        network_args = []
+        for i, arg in enumerate(self.virt_install.command_argv):
+            if arg == '--network' and i + 1 < len(self.virt_install.command_argv):
+                network_args.append(self.virt_install.command_argv[i + 1])
+
+        self.assertEqual(len(network_args), 1)
+        self.assertTrue(network_args[0].startswith('passt'))
+        self.assertIn('portForward0=8080:80', network_args[0])
+        self.assertIn('portForward1=3478/udp', network_args[0])
+        self.assertIn('portForward2=2222:22', network_args[0])
+
+    def test_network_passt_shorthand_no_port_forward(self):
+        """Test passt shorthand without port forwarding"""
+        self.mock_module.params = {
+            'name': 'test-vm',
+            'memory': 2048,
+            'networks': [
+                {'value': 'passt'}
+            ]
+        }
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install._build_command()
+
+        network_args = []
+        for i, arg in enumerate(self.virt_install.command_argv):
+            if arg == '--network' and i + 1 < len(self.virt_install.command_argv):
+                network_args.append(self.virt_install.command_argv[i + 1])
+
+        self.assertEqual(len(network_args), 1)
+        self.assertEqual(network_args[0], 'passt')
+
+    def test_network_user_type_with_backend(self):
+        """Test structured user/passt network with backend options"""
+        self.mock_module.params = {
+            'name': 'test-vm',
+            'memory': 2048,
+            'networks': [
+                {
+                    'type': 'user',
+                    'backend': {
+                        'type': 'passt',
+                        'log_file': '/tmp/passt.log'
+                    },
+                    'port_forward': ['8080:80']
+                }
+            ]
+        }
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install._build_command()
+
+        network_args = []
+        for i, arg in enumerate(self.virt_install.command_argv):
+            if arg == '--network' and i + 1 < len(self.virt_install.command_argv):
+                network_args.append(self.virt_install.command_argv[i + 1])
+
+        self.assertEqual(len(network_args), 1)
+        self.assertIn('type=user', network_args[0])
+        self.assertIn('backend.type=passt', network_args[0])
+        self.assertIn('backend.logFile=/tmp/passt.log', network_args[0])
+        self.assertIn('portForward0=8080:80', network_args[0])
+
+    def test_network_existing_forms_unchanged(self):
+        """Test backward compatibility — existing network forms still work"""
+        self.mock_module.params = {
+            'name': 'test-vm',
+            'memory': 2048,
+            'networks': [
+                {
+                    'network': 'default',
+                    'model': {'type': 'virtio'},
+                    'mac': {'address': '52:54:00:12:34:56'}
+                },
+                {
+                    'bridge': 'br0',
+                    'model': {'type': 'e1000'},
+                    'trust_guest_rx_filters': True
+                }
+            ]
+        }
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install._build_command()
+
+        network_args = []
+        for i, arg in enumerate(self.virt_install.command_argv):
+            if arg == '--network' and i + 1 < len(self.virt_install.command_argv):
+                network_args.append(self.virt_install.command_argv[i + 1])
+
+        self.assertEqual(len(network_args), 2)
+        self.assertIn('network=default', network_args[0])
+        self.assertIn('model.type=virtio', network_args[0])
+        self.assertIn('mac.address=52:54:00:12:34:56', network_args[0])
+        self.assertIn('bridge=br0', network_args[1])
+        self.assertIn('model.type=e1000', network_args[1])
+        self.assertIn('trustGuestRxFilters=yes', network_args[1])
+
+    def test_network_conflicting_selectors_rejected(self):
+        """Test that conflicting network selectors are rejected"""
+        self.mock_module.params = {
+            'name': 'test-vm',
+            'memory': 2048,
+            'networks': [
+                {
+                    'value': 'passt',
+                    'network': 'default',
+                    'port_forward': ['8080:80']
+                }
+            ]
+        }
+        self.mock_module.fail_json = mock.Mock()
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install._build_command()
+
+        self.mock_module.fail_json.assert_called_once()
+        args, kwargs = self.mock_module.fail_json.call_args
+        self.assertIn('conflicting', kwargs['msg'])
+
+    def test_network_passt_with_bridge_rejected(self):
+        """Test that value:passt combined with bridge is rejected"""
+        self.mock_module.params = {
+            'name': 'test-vm',
+            'memory': 2048,
+            'networks': [
+                {
+                    'value': 'passt',
+                    'bridge': 'br0'
+                }
+            ]
+        }
+        self.mock_module.fail_json = mock.Mock()
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install._build_command()
+
+        self.mock_module.fail_json.assert_called_once()
+        args, kwargs = self.mock_module.fail_json.call_args
+        self.assertIn('conflicting', kwargs['msg'])
+
     def test_graphics_configuration(self):
         """Test graphics configuration"""
         self.mock_module.params = {


### PR DESCRIPTION
##### SUMMARY

This PR adds passt network support to the shared `networks` schema used by both `virt_install` and `virt_cloud_instance`, so playbooks can express the same passt user-mode networking options that are already supported by `virt-install`. 

It supports both the shorthand `value: passt` form and a structured `type: user` form with `backend` and `port_forward` options, while preserving compatibility with existing network inputs. The change also adds documentation examples, a changelog fragment, validation for conflicting network selectors, and unit tests covering passt command generation and backward compatibility.

Fix #231 

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
`virt_install`
`virt_cloud_instance`

##### ADDITIONAL INFORMATION

**Full structured syntax**
```yaml
    networks:
      - type: user
        backend:
          type: passt
          logFile: /tmp/passt.log
        port_forward:
          - "8080:80"
```

**Shorthand syntax**
```yaml
    networks:
      - passt:
          port_forward:
            - "8080:80"
```
