### PR TITLE
feat(modules/virt): add get_ifaddresses function to retrive domain in…

### DIFF
--- a/changelogs/fragments/127-add-get-ifaddresses.yml
+++ b/changelogs/fragments/127-add-get-ifaddresses.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - virt - Add get_ifaddresses function to retrive domain interface addresses

--- a/plugins/doc_fragments/virt.py
+++ b/plugins/doc_fragments/virt.py
@@ -37,7 +37,7 @@ options:
     description:
       - In addition to state management, various non-idempotent commands are available.
     choices: [ create, define, destroy, freemem, get_xml, get_interfaces, info, list_vms, nodeinfo, pause, shutdown, start, status,
-               stop, undefine, unpause, uuid, virttype ]
+               stop, undefine, unpause, uuid, virttype, get_ifaddresses ]
     type: str
     """
 

--- a/plugins/module_utils/libvirt.py
+++ b/plugins/module_utils/libvirt.py
@@ -35,11 +35,17 @@ VIRT_STATE_NAME_MAP = {
     5: 'shutdown',
     6: 'crashed',
 }
-
+INTERFACE_ADDRESS_SOURCE_MAP = {
+    'lease': libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE,
+    'agent': libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT,
+    'arp': libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_ARP
+}
 
 class VMNotFound(Exception):
     pass
 
+class InvalidAddressSourceType(Exception):
+    pass
 
 class LibvirtConnection(object):
 
@@ -53,8 +59,7 @@ class LibvirtConnection(object):
         if "xen" in stdout:
             conn = libvirt.open(None)
         elif "esx" in uri:
-            auth = [[libvirt.VIR_CRED_AUTHNAME,
-                     libvirt.VIR_CRED_NOECHOPROMPT], [], None]
+            auth = [[libvirt.VIR_CRED_AUTHNAME,libvirt.VIR_CRED_NOECHOPROMPT], [], None]
             conn = libvirt.openAuth(uri, auth)
         else:
             conn = libvirt.open(uri)
@@ -150,6 +155,14 @@ class LibvirtConnection(object):
     def get_uuid(self, vmid):
         vm = self.conn.lookupByName(vmid)
         return vm.UUIDString()
+
+    def get_ifaddresses(self, vmid, flag):
+        try:
+            interface_address_source = INTERFACE_ADDRESS_SOURCE_MAP[flag]
+        except KeyError:
+            raise InvalidAddressSourceType
+        vm = self.conn.lookupByName(vmid)
+        return vm.interfaceAddresses(interface_address_source)
 
     def get_interfaces(self, vmid):
         dom_xml = self.get_xml(vmid)

--- a/plugins/module_utils/libvirt.py
+++ b/plugins/module_utils/libvirt.py
@@ -36,11 +36,14 @@ VIRT_STATE_NAME_MAP = {
     6: 'crashed',
 }
 
+
 class VMNotFound(Exception):
     pass
 
+
 class InvalidAddressSourceType(Exception):
     pass
+
 
 class LibvirtConnection(object):
 
@@ -54,7 +57,7 @@ class LibvirtConnection(object):
         if "xen" in stdout:
             conn = libvirt.open(None)
         elif "esx" in uri:
-            auth = [[libvirt.VIR_CRED_AUTHNAME,libvirt.VIR_CRED_NOECHOPROMPT], [], None]
+            auth = [[libvirt.VIR_CRED_AUTHNAME, libvirt.VIR_CRED_NOECHOPROMPT], [], None]
             conn = libvirt.openAuth(uri, auth)
         else:
             conn = libvirt.open(uri)

--- a/plugins/module_utils/libvirt.py
+++ b/plugins/module_utils/libvirt.py
@@ -35,11 +35,6 @@ VIRT_STATE_NAME_MAP = {
     5: 'shutdown',
     6: 'crashed',
 }
-INTERFACE_ADDRESS_SOURCE_MAP = {
-    'lease': libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE,
-    'agent': libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT,
-    'arp': libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_ARP
-}
 
 class VMNotFound(Exception):
     pass
@@ -157,8 +152,15 @@ class LibvirtConnection(object):
         return vm.UUIDString()
 
     def get_ifaddresses(self, vmid, flag):
+        if not HAS_VIRT:
+            raise Exception('python-libvirt is required for get_ifaddresses')
+        interface_address_source_map = {
+            'lease': libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE,
+            'agent': libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_AGENT,
+            'arp': libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_ARP
+        }
         try:
-            interface_address_source = INTERFACE_ADDRESS_SOURCE_MAP[flag]
+            interface_address_source = interface_address_source_map[flag]
         except KeyError:
             raise InvalidAddressSourceType
         vm = self.conn.lookupByName(vmid)

--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -26,7 +26,7 @@ options:
               Useful option to be able to C(undefine) guests with UEFI nvram.
               C(nvram) and C(keep_nvram) are conflicting and mutually exclusive.
               Consider option C(force) if all related metadata should be removed.
-              Specify which method to use when getting guest interface addresses using C(get_ifaddresses) 
+              Specify which method to use when getting guest interface addresses using C(get_ifaddresses)
               from either "lease", "agent" or "arp" (if list provided only first value is used).
         type: list
         elements: str
@@ -181,7 +181,10 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 ALL_COMMANDS = []
-VM_COMMANDS = ['create', 'define', 'destroy', 'get_xml', 'get_interfaces', 'get_ifaddresses', 'pause', 'shutdown', 'status', 'start', 'stop', 'undefine', 'unpause', 'uuid']
+VM_COMMANDS = [
+    'create', 'define', 'destroy', 'get_xml', 'get_interfaces', 'get_ifaddresses', 'pause', 'shutdown', 'status',
+    'start', 'stop', 'undefine', 'unpause', 'uuid'
+]
 HOST_COMMANDS = ['freemem', 'info', 'list_vms', 'nodeinfo', 'virttype']
 ALL_COMMANDS.extend(VM_COMMANDS)
 ALL_COMMANDS.extend(HOST_COMMANDS)

--- a/plugins/modules/virt.py
+++ b/plugins/modules/virt.py
@@ -18,14 +18,16 @@ description:
      - Manages virtual machines supported by I(libvirt).
 options:
     flags:
-        choices: [ 'managed_save', 'snapshots_metadata', 'nvram', 'keep_nvram', 'checkpoints_metadata', 'delete_volumes']
+        choices: [ 'managed_save', 'snapshots_metadata', 'nvram', 'keep_nvram', 'checkpoints_metadata', 'delete_volumes', 'lease', 'agent', 'arp']
         description:
             - Pass additional parameters.
-            - Currently only implemented with command C(undefine).
+            - Currently only implemented with command C(undefine) and C(get_ifaddresses).
               Specify which metadata should be removed with C(undefine).
               Useful option to be able to C(undefine) guests with UEFI nvram.
               C(nvram) and C(keep_nvram) are conflicting and mutually exclusive.
               Consider option C(force) if all related metadata should be removed.
+              Specify which method to use when getting guest interface addresses using C(get_ifaddresses) 
+              from either "lease", "agent" or "arp" (if list provided only first value is used).
         type: list
         elements: str
     force:
@@ -179,7 +181,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
 ALL_COMMANDS = []
-VM_COMMANDS = ['create', 'define', 'destroy', 'get_xml', 'get_interfaces', 'pause', 'shutdown', 'status', 'start', 'stop', 'undefine', 'unpause', 'uuid']
+VM_COMMANDS = ['create', 'define', 'destroy', 'get_xml', 'get_interfaces', 'get_ifaddresses', 'pause', 'shutdown', 'status', 'start', 'stop', 'undefine', 'unpause', 'uuid']
 HOST_COMMANDS = ['freemem', 'info', 'list_vms', 'nodeinfo', 'virttype']
 ALL_COMMANDS.extend(VM_COMMANDS)
 ALL_COMMANDS.extend(HOST_COMMANDS)
@@ -191,6 +193,9 @@ ENTRY_UNDEFINE_FLAGS_MAP = {
     'keep_nvram': 8,
     'checkpoints_metadata': 16,
     'delete_volumes': 32,
+    'lease': 64,
+    'agent': 128,
+    'arp': 256
 }
 
 MUTATE_FLAGS = ['ADD_UUID', 'ADD_MAC_ADDRESSES', 'ADD_MAC_ADDRESSES_FUZZY']
@@ -393,6 +398,13 @@ class Virt(object):
     def get_uuid(self, vmid):
         self.__get_conn()
         return self.conn.get_uuid(vmid)
+
+    def get_ifaddresses(self, vmid, flag):
+        """
+        Get Interface Name and Mac Address from xml
+        """
+        self.__get_conn()
+        return self.conn.get_ifaddresses(vmid, flag)
 
     def get_interfaces(self, vmid):
         """
@@ -707,7 +719,8 @@ def core(module):
 
             elif command == 'uuid':
                 res = {'uuid': v.get_uuid(guest)}
-
+            elif command == 'get_ifaddresses':
+                res = v.get_ifaddresses(guest, flags[0])
             else:
                 res = exec_virt(guest)
 


### PR DESCRIPTION
##### SUMMARY
Adding get_interfaces function described in #124 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module_utils/libvirt.py
modules/virt.py

##### ADDITIONAL INFORMATION
using in tasks, flags can be either lease, arp or agent. e.g. 
```yaml
- name: get vm
  community.libvirt.virt:
    name: "opensuse_tumbleweed_latest"
    command: get_ifaddresses
    flags: arp
  register: vm_info
- name: print vm info
  ansible.builtin.debug:
    msg: "{{ vm_info }}"
```
will return something like
```json
ok: [localhost] => {
    "msg": {
        "changed": false,
        "failed": false,
        "vnet33": {
            "addrs": [
                {
                    "addr": "192.168.122.165",
                    "prefix": 0,
                    "type": 0
                }
            ],
            "hwaddr": "52:54:00:e7:85:6f"
        }
    }
}
```