### PR TITLE
fix: make install.os optional to support no_install without OS (#250)

### DIFF
--- a/changelogs/fragments/268-fix-no-install-os-required.yaml
+++ b/changelogs/fragments/268-fix-no-install-os-required.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "virt_install - remove incorrect ``required=True`` from ``install.os`` parameter to allow ``install.no_install=true`` without specifying an OS."

--- a/plugins/doc_fragments/virt_install.py
+++ b/plugins/doc_fragments/virt_install.py
@@ -842,7 +842,7 @@ options:
         type: str
         description:
           - The OS name from I(libosinfo), e.g. V(fedora29).
-        required: true
+          - This is not required when O(install.no_install=true) is set.
       kernel:
         type: str
         description:

--- a/plugins/module_utils/virt_install.py
+++ b/plugins/module_utils/virt_install.py
@@ -1406,7 +1406,7 @@ def get_install_args():
         install=dict(
             type='dict',
             options=dict(
-                os=dict(type='str', required=True),
+                os=dict(type='str'),
                 kernel=dict(type='str'),
                 initrd=dict(type='str'),
                 kernel_args=dict(type='str'),

--- a/tests/unit/module_utils/test_virt_install.py
+++ b/tests/unit/module_utils/test_virt_install.py
@@ -9,7 +9,8 @@ import shutil
 
 from ansible_collections.community.libvirt.tests.unit.compat import mock
 from ansible_collections.community.libvirt.plugins.module_utils.virt_install import (
-    _dict2options, _get_option_mapping, OPTION_BOOL_ONOFF, VirtInstallTool)
+    _dict2options, _get_option_mapping, OPTION_BOOL_ONOFF, VirtInstallTool,
+    get_install_args)
 
 
 class TestDict2Options(unittest.TestCase):
@@ -286,6 +287,21 @@ class TestDict2Options(unittest.TestCase):
 
         for part in expected_parts:
             self.assertIn(part, result)
+
+
+class TestGetInstallArgs(unittest.TestCase):
+
+    def test_install_os_not_required(self):
+        args = get_install_args()
+        install_options = args['install']['options']
+        self.assertTrue(
+            install_options['os'].get('required', False) is not True,
+            "install.os should not be marked as required")
+
+    def test_no_install_option_exists(self):
+        args = get_install_args()
+        install_options = args['install']['options']
+        self.assertIn('no_install', install_options)
 
 
 class TestPrimaryValueFeature(unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY

The install.os parameter was incorrectly marked as required=True in the argument spec, preventing install.no_install=true from working without specifying an OS. When no_install is set, virt-install just creates the VM without an install phase, so OS is unnecessary.

Fixes #250 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`virt_install`

##### ADDITIONAL INFORMATION
