### PR TITLE
chore(ci): upgrade default test container to 8.0.0 and fix cloud instance tests

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -36,6 +36,8 @@ variables:
 resources:
   containers:
     - container: default
+      image: quay.io/ansible/azure-pipelines-test-container:8.0.0
+    - container: legacy_py312
       image: quay.io/ansible/azure-pipelines-test-container:7.0.0
 
 pool: Standard
@@ -110,6 +112,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
+          container: legacy_py312
           targets:
             - name: Sanity
               test: '2.17/sanity/1'
@@ -188,6 +191,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
+          container: legacy_py312
           testFormat: 2.17/linux/{0}/1
           targets:
             - name: Fedora 39

--- a/.azure-pipelines/templates/matrix.yml
+++ b/.azure-pipelines/templates/matrix.yml
@@ -40,9 +40,15 @@ parameters:
     type: string
     default: "{0}/{{1}}"
 
+  # Optional container resource alias used by generated test jobs.
+  - name: container
+    type: string
+    default: default
+
 jobs:
   - template: test.yml
     parameters:
+      container: ${{ parameters.container }}
       jobs:
         - ${{ if eq(length(parameters.groups), 0) }}:
           - ${{ each target in parameters.targets }}:

--- a/.azure-pipelines/templates/test.yml
+++ b/.azure-pipelines/templates/test.yml
@@ -6,12 +6,16 @@ parameters:
   # Each item in the list must contain a "job" and "name" key.
   - name: jobs
     type: object
+  # Optional container resource alias used to execute test jobs.
+  - name: container
+    type: string
+    default: default
 
 jobs:
   - ${{ each job in parameters.jobs }}:
     - job: test_${{ replace(replace(replace(job.test, '/', '_'), '.', '_'), '-', '_') }}
       displayName: ${{ job.name }}
-      container: default
+      container: ${{ parameters.container }}
       workspace:
         clean: all
       steps:

--- a/tests/unit/modules/test_virt_cloud_instance.py
+++ b/tests/unit/modules/test_virt_cloud_instance.py
@@ -1261,7 +1261,10 @@ class TestCore(unittest.TestCase):
 
         # Verify behavior
         mock_validate_disks.assert_called_once()
-        mock_virt_conn.find_vm.assert_called_once_with('test-vm')
+        # find_vm is called twice: pre-create lookup and post-create reverify
+        # for wait_for_cloud_init_reboot (see plugins/modules/virt_cloud_instance.py)
+        self.assertEqual(mock_virt_conn.find_vm.call_count, 2)
+        mock_virt_conn.find_vm.assert_called_with('test-vm')
         mock_operator.fetch_image.assert_called_once_with(False, timeout=None)
         mock_operator.validate_checksum.assert_called_once()
         mock_operator.build_system_disk.assert_called_once()
@@ -1355,7 +1358,10 @@ class TestCore(unittest.TestCase):
         rc, result = core(self.mock_module)
 
         # Verify VM destruction and recreation
-        mock_virt_conn.find_vm.assert_called_once_with('test-vm')
+        # find_vm is called twice: pre-create lookup and post-create reverify
+        # for wait_for_cloud_init_reboot (see plugins/modules/virt_cloud_instance.py)
+        self.assertEqual(mock_virt_conn.find_vm.call_count, 2)
+        mock_virt_conn.find_vm.assert_called_with('test-vm')
         mock_virt_conn.destroy.assert_called_once_with('test-vm')
         mock_virt_conn.undefine.assert_called_once_with('test-vm')
 


### PR DESCRIPTION
##### SUMMARY

The default Azure Pipelines test container is upgraded from 7.0.0 to 8.0.0 so that newer ansible-core versions (2.18+/2.21) run against the current test environment. The 7.0.0 image is retained under a legacy_py312 alias and is explicitly used for ansible-core 2.17 sanity and integration targets to preserve backward compatibility. To support this, the container resource is made configurable via a new container parameter in the matrix.yml and test.yml templates, replacing the previous hardcoded default reference.

Additionally, the find_vm call-count assertion in test_virt_cloud_instance.py is corrected. The function is invoked twice in the module — once for the pre-create domain lookup and again for the post-create re-verification inside wait_for_cloud_init_reboot — and the test now accurately reflects this behavior.

Fixes #267

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
N/A

##### ADDITIONAL INFORMATION
N/A
