### PR TITLE
feat(virt_install): add wait_timeout parameter for multi-phase installs

### DIFF
--- a/changelogs/fragments/272-virt-install-wait-timeout.yaml
+++ b/changelogs/fragments/272-virt-install-wait-timeout.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "virt_install - add ``wait_timeout`` parameter to wait for multi-phase unattended installs to complete."

--- a/plugins/modules/virt_install.py
+++ b/plugins/modules/virt_install.py
@@ -34,6 +34,13 @@ options:
     description:
       - Use with present to force the re-creation of an existing VM.
     default: false
+  wait_timeout:
+    type: int
+    version_added: '2.3.0'
+    description:
+      - Maximum time in seconds to wait for the install to complete (rounded up to the nearest whole minute when passed to C(virt-install --wait)).
+      - When unset, the module will not pass C(--wait) to C(virt-install) and will start the install then exit (the module always uses C(--noautoconsole)).
+      - Use this for multi-phase unattended installs that reboot into a final post-install phase.
 extends_documentation_fragment:
     - community.libvirt.virt.options_uri
     - community.libvirt.virt_install.options_memory
@@ -348,6 +355,10 @@ def core(module):
     name = module.params.get('name')
     uri = module.params.get('uri')
     recreate = module.params.get('recreate', False)
+    wait_timeout = module.params.get('wait_timeout')
+    if wait_timeout is not None and wait_timeout <= 0:
+        module.fail_json(
+            msg="wait_timeout must be a positive integer (seconds)")
 
     result = dict(
         changed=False,
@@ -379,7 +390,8 @@ def core(module):
             virtConn.undefine(name)
 
         # run virt-install to create new vm
-        changed, rc, extra_res = virtInstall.execute(dryrun=module.check_mode)
+        changed, rc, extra_res = virtInstall.execute(
+            dryrun=module.check_mode, wait_timeout=wait_timeout)
         result['changed'] = changed
         result['commands'].extend(virtInstall.get_commands())
         result.update(extra_res)
@@ -414,6 +426,7 @@ def main():
             choices=['present', 'absent'],
             default='present'),
         recreate=dict(type='bool', default=False),
+        wait_timeout=dict(type='int'),
     )
 
     # General options

--- a/tests/unit/module_utils/test_virt_install.py
+++ b/tests/unit/module_utils/test_virt_install.py
@@ -2501,6 +2501,43 @@ class TestVirtInstallToolExecute(unittest.TestCase):
         self.assertIn('virt-install', called_args)
         self.assertIn('--noautoconsole', called_args)
 
+    def test_execute_wait_timeout_rounds_up_to_minutes(self):
+        """Test wait_timeout (seconds) is rounded up to whole minutes"""
+        self.mock_module.run_command.return_value = (
+            0, "Domain installation proceeding...", "")
+
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install.execute(wait_timeout=90)
+
+        called_args = self.mock_module.run_command.call_args[0][0]
+        self.assertIn('--wait', called_args)
+        # 90 seconds -> ceil(90/60) = 2 minutes
+        wait_index = called_args.index('--wait')
+        self.assertEqual(called_args[wait_index + 1], '2')
+
+    def test_execute_wait_timeout_whole_minutes(self):
+        """Test wait_timeout that is an exact multiple of 60"""
+        self.mock_module.run_command.return_value = (
+            0, "Domain installation proceeding...", "")
+
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install.execute(wait_timeout=120)
+
+        called_args = self.mock_module.run_command.call_args[0][0]
+        wait_index = called_args.index('--wait')
+        self.assertEqual(called_args[wait_index + 1], '2')
+
+    def test_execute_no_wait_timeout_omits_wait_flag(self):
+        """Test that omitting wait_timeout does not add --wait"""
+        self.mock_module.run_command.return_value = (
+            0, "Domain installation proceeding...", "")
+
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install.execute()
+
+        called_args = self.mock_module.run_command.call_args[0][0]
+        self.assertNotIn('--wait', called_args)
+
     def test_execute_failure(self):
         """Test failed execution"""
         error_message = "ERROR: Unable to connect to libvirt"

--- a/tests/unit/modules/test_virt_install.py
+++ b/tests/unit/modules/test_virt_install.py
@@ -70,7 +70,55 @@ class TestCoreFunction(unittest.TestCase):
         self.assertEqual(rc, VIRT_SUCCESS)
         self.assertTrue(result['changed'])
         self.assertEqual(result['msg'], "VM created successfully")
-        mock_virt_install.execute.assert_called_once_with(dryrun=False)
+        mock_virt_install.execute.assert_called_once_with(dryrun=False, wait_timeout=None)
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.LibvirtWrapper')
+    def test_core_wait_timeout_forwarded(
+            self, mock_libvirt_wrapper, mock_virt_install_tool):
+        """Test core() forwards wait_timeout to execute()"""
+        mock_virt_conn = mock.Mock()
+        mock_virt_install = mock.Mock()
+        mock_libvirt_wrapper.return_value = mock_virt_conn
+        mock_virt_install_tool.return_value = mock_virt_install
+
+        mock_virt_conn.find_vm.side_effect = VMNotFound("VM not found")
+        mock_virt_install.execute.return_value = (
+            True, VIRT_SUCCESS, {"msg": "VM created successfully"})
+        mock_virt_install.get_commands.return_value = []
+
+        self.mock_module.params['wait_timeout'] = 120
+
+        rc, result = core(self.mock_module)
+
+        mock_virt_install.execute.assert_called_once_with(
+            dryrun=False, wait_timeout=120)
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.LibvirtWrapper')
+    def test_core_wait_timeout_zero_rejected(
+            self, mock_libvirt_wrapper, mock_virt_install_tool):
+        """Test core() rejects wait_timeout=0"""
+        self.mock_module.params['wait_timeout'] = 0
+
+        with self.assertRaises(Exception) as context:
+            core(self.mock_module)
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="wait_timeout must be a positive integer (seconds)")
+
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.VirtInstallTool')
+    @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.LibvirtWrapper')
+    def test_core_wait_timeout_negative_rejected(
+            self, mock_libvirt_wrapper, mock_virt_install_tool):
+        """Test core() rejects negative wait_timeout"""
+        self.mock_module.params['wait_timeout'] = -5
+
+        with self.assertRaises(Exception) as context:
+            core(self.mock_module)
+
+        self.mock_module.fail_json.assert_called_once_with(
+            msg="wait_timeout must be a positive integer (seconds)")
 
     @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.VirtInstallTool')
     @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.LibvirtWrapper')
@@ -158,7 +206,7 @@ class TestCoreFunction(unittest.TestCase):
         # Should not be called if VM is inactive
         mock_virt_conn.destroy.assert_not_called()
         mock_virt_conn.undefine.assert_called_once_with('test-vm')
-        mock_virt_install.execute.assert_called_once_with(dryrun=False)
+        mock_virt_install.execute.assert_called_once_with(dryrun=False, wait_timeout=None)
 
     @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.VirtInstallTool')
     @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.LibvirtWrapper')
@@ -192,7 +240,7 @@ class TestCoreFunction(unittest.TestCase):
         self.assertEqual(result['msg'], "VM recreated successfully")
         mock_virt_conn.destroy.assert_called_once_with('test-vm')
         mock_virt_conn.undefine.assert_called_once_with('test-vm')
-        mock_virt_install.execute.assert_called_once_with(dryrun=False)
+        mock_virt_install.execute.assert_called_once_with(dryrun=False, wait_timeout=None)
 
     @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.VirtInstallTool')
     @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.LibvirtWrapper')
@@ -333,7 +381,7 @@ class TestCoreFunction(unittest.TestCase):
 
         # Assertions
         self.assertEqual(rc, VIRT_SUCCESS)
-        mock_virt_install.execute.assert_called_once_with(dryrun=True)
+        mock_virt_install.execute.assert_called_once_with(dryrun=True, wait_timeout=None)
 
     @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.VirtInstallTool')
     @mock.patch('ansible_collections.community.libvirt.plugins.modules.virt_install.LibvirtWrapper')


### PR DESCRIPTION
##### SUMMARY

Add an optional wait_timeout parameter to community.libvirt.virt_install so the module can wait for multi-phase installs that reboot and continue into a final post-install phase.

The value is specified in seconds, must be a positive integer, and is translated to virt-install --wait rounded up to whole minutes. When omitted, the existing non-blocking behavior is preserved.

Fixes #253

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`virt_install`

##### ADDITIONAL INFORMATION

Example playbook for an ISO-based unattended install that needs `virt-install` to stay alive across the installer reboot and complete the final post-install phase:

```yaml
- name: Create VM from ISO and wait for unattended install to complete
  community.libvirt.virt_install:
    name: ubuntu-server
    memory: 2048
    vcpus: 2
    wait_timeout: 1800  # seconds; passed to virt-install --wait as 30 minutes
    disks:
      - size: 25
    osinfo:
      name: ubuntu20.04
    cdrom: /var/lib/libvirt/images/ubuntu-20.04-live-server-amd64.iso
    unattended:
      profile: jeos
      admin_password_file: /tmp/root_password
      user_login: ansible
      user_password_file: /tmp/user_password
    networks:
      - network: default
```

