### PR TITLE
feat(virt_install): add wwn disk parameter

### DIFF
--- a/changelogs/fragments/273-wwn-disk-param.yml
+++ b/changelogs/fragments/273-wwn-disk-param.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - virt_install - add ``wwn`` parameter to disk specifications for setting the World Wide Name of a disk device (https://github.com/ansible-collections/community.libvirt/issues/271).

--- a/plugins/doc_fragments/virt_install.py
+++ b/plugins/doc_fragments/virt_install.py
@@ -1049,6 +1049,12 @@ options:
         type: str
         description:
           - An existing libvirt storage volume to use.
+      wwn:
+        type: str
+        description:
+          - World Wide Name for the disk device.
+          - Maps to the V(wwn) element in libvirt domain XML.
+        version_added: 2.3.0
       size:
         type: int
         description:

--- a/plugins/module_utils/virt_install.py
+++ b/plugins/module_utils/virt_install.py
@@ -1509,6 +1509,7 @@ def get_disks_args():
                 path=dict(type='str'),
                 pool=dict(type='str'),
                 vol=dict(type='str'),
+                wwn=dict(type='str'),
                 size=dict(type='int'),
                 sparse=dict(type='bool'),
                 format=dict(type='str'),

--- a/tests/unit/module_utils/test_virt_install.py
+++ b/tests/unit/module_utils/test_virt_install.py
@@ -1087,6 +1087,30 @@ class TestBuildCommand(unittest.TestCase):
         self.assertIn('readonly=no', disk_args[1])
         self.assertIn('shareable=yes', disk_args[1])
 
+    def test_disk_wwn_parameter(self):
+        """Test that wwn parameter is passed through to --disk argument"""
+        self.mock_module.params = {
+            'name': 'test-vm',
+            'memory': 2048,
+            'disks': [
+                {
+                    'size': 20,
+                    'bus': 'scsi',
+                    'wwn': '0x5000c50015ea71ad'
+                }
+            ]
+        }
+        self.virt_install = VirtInstallTool(self.mock_module)
+        self.virt_install._build_command()
+
+        disk_args = []
+        for i, arg in enumerate(self.virt_install.command_argv):
+            if arg == '--disk' and i + 1 < len(self.virt_install.command_argv):
+                disk_args.append(self.virt_install.command_argv[i + 1])
+
+        self.assertEqual(len(disk_args), 1)
+        self.assertIn('wwn=0x5000c50015ea71ad', disk_args[0])
+
     def test_network_configuration(self):
         """Test network configuration"""
         self.mock_module.params = {


### PR DESCRIPTION
##### SUMMARY
Add `wwn` (World Wide Name) as a top-level parameter in virt_install disk specifications, allowing users to set a disk device WWN via `virt-install --disk wwn=...` (mapping to the wwn element in libvirt domain XML). Documentation is updated and a unit test ensures the parameter is passed through correctly.

Fixes #271

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`virt_install`

##### ADDITIONAL INFORMATION

Example usage:
```yaml
- name: Install VM with disk WWN
  community.libvirt.virt_install:
    name: test-vm
    memory: 2048
    disks:
      - size: 20
        bus: scsi
        wwn: "0x5000c50015ea71ad"
```

Expected virt-install argument contains:
`--disk size=20,bus=scsi,wwn=0x5000c50015ea71ad`
